### PR TITLE
Add support for Semeru builds

### DIFF
--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -349,9 +349,15 @@ class Regeneration implements Serializable {
         String estimatedKey = stringArch + stringOs.capitalize()
 
         if (configuration.containsKey("additionalFileNameTag")) {
-            estimatedKey = estimatedKey + "XL"
+            String stringAdditionalFileNameTag = configuration.additionalFileNameTag as String
+            if (stringAdditionalFileNameTag.contains('XL')) {
+                estimatedKey = estimatedKey + "XL"
+            } else {
+                estimatedKey += stringAdditionalFileNameTag
+            }
         }
 
+        
         if (excludedBuilds.containsKey(estimatedKey)) {
 
             if (excludedBuilds[estimatedKey].contains(variant)) {

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -1,291 +1,291 @@
 class Config11 {
   final Map<String, Map<String, ?>> buildConfigurations = [
         x64Mac    : [
-                os                  : 'mac',
-                arch                : 'x64',
-                additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.osx.10_14',
-                test                : false,
-                configureArgs       : [
-                        "openj9"      : '--enable-dtrace=auto',
-                        "hotspot"     : '--enable-dtrace=auto'
-                ]
+            os                  : 'mac',
+            arch                : 'x64',
+            additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.osx.10_14',
+            test                : false,
+            configureArgs       : [
+                    "openj9"      : '--enable-dtrace=auto  --with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="11.0.12.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues',
+                    "hotspot"     : '--enable-dtrace=auto'
+            ]
         ],
 
         x64MacXL    : [
-                os                   : 'mac',
-                arch                 : 'x64',
-                additionalNodeLabels: 'macos10.14',
-                test                 : 'default',
-                additionalFileNameTag: "macosXL",
-                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
+            os                   : 'mac',
+            arch                 : 'x64',
+            additionalNodeLabels: 'macos10.14',
+            test                 : 'default',
+            additionalFileNameTag: "macosXL",
+            configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
 
         x64MacIBM    : [
-                os                  : 'mac',
-                arch                : 'x64',
-                additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.osx.10_14',
-                test                : 'default',
-                configureArgs       : [
-                        "openj9"      : '--enable-dtrace=auto  --with-vendor-name="IBM Corporation" --with-vendor-version-string="11.0.11.0-IBM" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://www.ibm.com/support/pages/java-sdk-support --with-vendor-vm-bug-url=https://www.ibm.com/support/pages/java-sdk-support --with-jdk-rc-name="IBM Java Platform"'
-                ],
-                additionalFileNameTag: "IBM",
-                buildArgs : "--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk"
+            os                  : 'mac',
+            arch                : 'x64',
+            additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.osx.10_14',
+            test                : 'default',
+            configureArgs       : [
+                    "openj9"      : '--enable-dtrace=auto  --with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="11.0.12.0" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
+            ],
+            additionalFileNameTag: "IBM",
+            buildArgs : "--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk"
         ],
 
         x64Linux  : [
-                os                  : 'linux',
-                arch                : 'x64',
-                additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
-                dockerImage         : 'adoptopenjdk/centos6_build_image@sha256:19cdb5284da031aef7c73cb52ee7018502d65d0ca21cebc45d9652eec3926458',
-                dockerFile: [
-                        openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
-                ],
-                dockerNode          : 'sw.tool.docker && sw.config.uid1000',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
-                test                : false,
-                configureArgs       : [
-                        "openj9"      : '--enable-jitserver --enable-dtrace=auto',
-                        "hotspot"     : '--enable-dtrace=auto',
-                        "corretto"    : '--enable-dtrace=auto',
-                        "SapMachine"  : '--enable-dtrace=auto',
-                        "dragonwell"  : '--enable-dtrace=auto --enable-unlimited-crypto --with-jvm-variants=server --with-zlib=system --with-jvm-features=zgc',
-                        "bisheng"     : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server --disable-warnings-as-errors'
-                ]
+            os                  : 'linux',
+            arch                : 'x64',
+            additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
+            dockerImage         : 'adoptopenjdk/centos6_build_image@sha256:19cdb5284da031aef7c73cb52ee7018502d65d0ca21cebc45d9652eec3926458',
+            dockerFile: [
+                    openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
+            ],
+            dockerNode          : 'sw.tool.docker && sw.config.uid1000',
+            dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
+            test                : false,
+            configureArgs       : [
+                    "openj9"      : '--enable-jitserver --enable-dtrace=auto --with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="11.0.12.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues',
+                    "hotspot"     : '--enable-dtrace=auto',
+                    "corretto"    : '--enable-dtrace=auto',
+                    "SapMachine"  : '--enable-dtrace=auto',
+                    "dragonwell"  : '--enable-dtrace=auto --enable-unlimited-crypto --with-jvm-variants=server --with-zlib=system --with-jvm-features=zgc',
+                    "bisheng"     : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server --disable-warnings-as-errors'
+            ]
         ],
 
         x64LinuxIBM  : [
-                os                  : 'linux',
-                arch                : 'x64',
-                additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
-                dockerImage         : 'adoptopenjdk/centos6_build_image@sha256:19cdb5284da031aef7c73cb52ee7018502d65d0ca21cebc45d9652eec3926458',
-                dockerFile: [
-                        openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
-                ],
-                dockerNode          : 'sw.tool.docker && sw.config.uid1000',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
-                test                : 'default',
-                configureArgs       : [
-                        "openj9"      : '--enable-jitserver --enable-dtrace=auto --with-vendor-name="IBM Corporation" --with-vendor-version-string="11.0.12.0-IBM" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://www.ibm.com/support/pages/java-sdk-support --with-vendor-vm-bug-url=https://www.ibm.com/support/pages/java-sdk-support --with-jdk-rc-name="IBM Java Platform"'
-                ],
-                additionalFileNameTag: "IBM",
-                buildArgs : "--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk"
+            os                  : 'linux',
+            arch                : 'x64',
+            additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
+            dockerImage         : 'adoptopenjdk/centos6_build_image@sha256:19cdb5284da031aef7c73cb52ee7018502d65d0ca21cebc45d9652eec3926458',
+            dockerFile: [
+                    "openj9"  : 'pipelines/build/dockerFiles/cuda.dockerfile'
+            ],
+            dockerNode          : 'sw.tool.docker && sw.config.uid1000',
+            dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
+            test                : 'default',
+            configureArgs       : [
+                    "openj9"      : '--enable-jitserver --enable-dtrace=auto --with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="11.0.12.0" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
+            ],
+            additionalFileNameTag: "IBM",
+            buildArgs : "--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk"
         ],
 
         x64Windows: [
-                os                  : 'windows',
-                arch                : 'x64',
-                additionalNodeLabels: [
-                        hotspot:    'win2012',
-                        openj9:     'ci.project.openj9 && hw.arch.x86 && sw.os.windows',
-                        dragonwell: 'win2012'
-                ],
-                buildArgs : [
-                        hotspot : '--jvm-variant client,server'
-                ],
-                test                : false
+            os                  : 'windows',
+            arch                : 'x64',
+            additionalNodeLabels: [
+                    openj9:     'ci.project.openj9 && hw.arch.x86 && sw.os.windows',
+                    hotspot:    'win2012',
+                    dragonwell: 'win2012'
+            ],
+            test                : false,
+            configureArgs       : [
+                    "openj9"      : '--with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="11.0.12.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-jdk-rc-name="IBM Semeru Runtime"',
+                    "hotspot" : '--jvm-variant client,server'
+            ]
         ],
 
         x64WindowsIBM: [
-                os                  : 'windows',
-                arch                : 'x64',
-                additionalNodeLabels: [
-                        openj9:     'ci.project.openj9 && hw.arch.x86 && sw.os.windows'
-                ],
-                buildArgs : [
-                        openj9 : "--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk"
-                ],
-                test                : 'default',
-                configureArgs       : [
-                        "openj9"      : '--with-vendor-name="IBM Corporation" --with-vendor-version-string="11.0.12.0-IBM" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://www.ibm.com/support/pages/java-sdk-support --with-vendor-vm-bug-url=https://www.ibm.com/support/pages/java-sdk-support --with-jdk-rc-name="IBM Java Platform"'
-                ],
-                additionalFileNameTag: "IBM"
+            os                  : 'windows',
+            arch                : 'x64',
+            additionalNodeLabels: [
+                    openj9:     'ci.project.openj9 && hw.arch.x86 && sw.os.windows'
+            ],
+            buildArgs : [
+                    openj9 : "--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk"
+            ],
+            test                : 'default',
+            configureArgs       : [
+                    "openj9"      : '--with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="11.0.12.0" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-jdk-rc-name="IBM Semeru Runtime"'
+            ],
+            additionalFileNameTag: "IBM"
         ],
 
         x64WindowsXL    : [
-                os                   : 'windows',
-                arch                 : 'x64',
-                additionalNodeLabels : 'win2012&&vs2017',
-                test                 : 'default',
-                additionalFileNameTag: "windowsXL",
-                configureArgs        : '--with-noncompressedrefs'
+            os                   : 'windows',
+            arch                 : 'x64',
+            additionalNodeLabels : 'win2012&&vs2017',
+            test                 : 'default',
+            additionalFileNameTag: "windowsXL",
+            configureArgs        : '--with-noncompressedrefs'
         ],
 
         x32Windows: [
-                os                  : 'windows',
-                arch                : 'x86-32',
-                additionalNodeLabels: 'win2012',
-                buildArgs : [
-                        hotspot : '--jvm-variant client,server'
-                ],
-                test                : 'default'
+            os                  : 'windows',
+            arch                : 'x86-32',
+            additionalNodeLabels: 'win2012',
+            buildArgs : [
+                    hotspot : '--jvm-variant client,server'
+            ],
+            test                : 'default'
         ],
 
         ppc64Aix    : [
-                os                  : 'aix',
-                arch                : 'ppc64',
-                additionalNodeLabels: [
-                        hotspot: 'xlc13&&aix710',
-                        openj9:  'hw.arch.ppc64 && sw.os.aix.7_1'
-                ],
-                test                : false,
-                cleanWorkspaceAfterBuild: true
+            os                  : 'aix',
+            arch                : 'ppc64',
+            additionalNodeLabels: [
+                    openj9:  'hw.arch.ppc64 && sw.os.aix.7_1'
+            ],
+            test                : false,
+            configureArgs       : [
+                    "openj9"      : '--with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="11.0.12.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
+            ]
         ],
 
         ppc64AixIBM    : [
-                os                  : 'aix',
-                arch                : 'ppc64',
-                additionalNodeLabels: [
-                        openj9:  'hw.arch.ppc64 && sw.os.aix.7_1'
-                ],
-                test                : 'default',
-                configureArgs       : [
-                        "openj9"      : '--with-vendor-name="IBM Corporation" --with-vendor-version-string="11.0.12.0-IBM" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://www.ibm.com/support/pages/java-sdk-support --with-vendor-vm-bug-url=https://www.ibm.com/support/pages/java-sdk-support --with-jdk-rc-name="IBM Java Platform"'
-                ],
-                additionalFileNameTag: "IBM",
-                buildArgs : "--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk"
+            os                  : 'aix',
+            arch                : 'ppc64',
+            additionalNodeLabels: [
+                    openj9:  'hw.arch.ppc64 && sw.os.aix.7_1'
+            ],
+            test                : 'default',
+            configureArgs       : [
+                    "openj9"      : '--with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="11.0.12.0" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
+            ],
+            additionalFileNameTag: "IBM",
+            buildArgs : "--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk"
         ],
 
         s390xLinux    : [
-                os                  : 'linux',
-                arch                : 's390x',
-                test                : false,
-                additionalNodeLabels: [
-                        openj9:  'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)'
-                ],
-                configureArgs       : '--enable-dtrace=auto'
+            os                  : 'linux',
+            arch                : 's390x',
+            test                : false,
+            additionalNodeLabels: [
+                    openj9:  'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)'
+            ],
+            configureArgs       : '--enable-dtrace=auto --with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="11.0.12.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
         ],
 
         s390xLinuxIBM    : [
-                os                  : 'linux',
-                arch                : 's390x',
-                test                : 'default',
-                additionalNodeLabels: [
-                        openj9:  'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)'
-                ],
-                configureArgs       : '--enable-dtrace=auto --with-vendor-name="IBM Corporation" --with-vendor-version-string="11.0.12.0-IBM" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://www.ibm.com/support/pages/java-sdk-support --with-vendor-vm-bug-url=https://www.ibm.com/support/pages/java-sdk-support --with-jdk-rc-name="IBM Java Platform"',
-                additionalFileNameTag: "IBM",
-                buildArgs : "--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk"
+            os                  : 'linux',
+            arch                : 's390x',
+            test                : 'default',
+            additionalNodeLabels: [
+                    openj9:  'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)'
+            ],
+                configureArgs       : '--enable-dtrace=auto --with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="11.0.12.0" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues',
+            additionalFileNameTag: "IBM",
+            buildArgs : "--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk"
         ],
 
         sparcv9Solaris    : [
-                os                  : 'solaris',
-                arch                : 'sparcv9',
-                test                : false,
-                configureArgs       : '--enable-dtrace=auto'
+            os                  : 'solaris',
+            arch                : 'sparcv9',
+            test                : false,
+            configureArgs       : '--enable-dtrace=auto'
         ],
 
         ppc64leLinux    : [
-                os                  : 'linux',
-                arch                : 'ppc64le',
-                additionalNodeLabels : 'centos7',
-                test                : false,
-                additionalNodeLabels: [
-                        openj9:  'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)'
-                ],
-                configureArgs       : [
-                        "hotspot"     : '--enable-dtrace=auto',
-                        "openj9"      : '--enable-dtrace=auto --enable-jitserver'
-                ]
-
+            os                  : 'linux',
+            arch                : 'ppc64le',
+            additionalNodeLabels : 'centos7',
+            test                : false,
+            additionalNodeLabels: [
+                    openj9:  'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)'
+            ],
+            configureArgs       : [
+                    "hotspot"     : '--enable-dtrace=auto',
+                    "openj9"      : '--enable-dtrace=auto --enable-jitserver --with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="11.0.12.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
+            ]
         ],
 
         ppc64leLinuxIBM    : [
-                os                  : 'linux',
-                arch                : 'ppc64le',
-                additionalNodeLabels : 'centos7',
-                test                : 'default',
-                additionalNodeLabels: [
-                        openj9:  'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)'
-                ],
-                configureArgs       : [
-                        "openj9"      : '--enable-dtrace=auto --enable-jitserver --with-vendor-name="IBM Corporation" --with-vendor-version-string="11.0.12.0-IBM" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://www.ibm.com/support/pages/java-sdk-support --with-vendor-vm-bug-url=https://www.ibm.com/support/pages/java-sdk-support --with-jdk-rc-name="IBM Java Platform"'
-                ],
-                additionalFileNameTag: "IBM",
-                buildArgs : "--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk"
-
+            os                  : 'linux',
+            arch                : 'ppc64le',
+            additionalNodeLabels : 'centos7',
+            test                : 'default',
+            additionalNodeLabels: [
+                    openj9:  'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)'
+            ],
+            configureArgs       : [
+                        "openj9"      : '--enable-dtrace=auto --enable-jitserver --with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="11.0.12.0" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
+            ],
+            additionalFileNameTag: "IBM",
+            buildArgs : "--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk"
         ],
 
         arm32Linux    : [
-                os                  : 'linux',
-                arch                : 'arm',
-                test                : 'default',
-                configureArgs       : '--enable-dtrace=auto'
+            os                  : 'linux',
+            arch                : 'arm',
+            test                : 'default',
+            configureArgs       : '--enable-dtrace=auto'
         ],
 
         aarch64Linux    : [
-                os                  : 'linux',
-                arch                : 'aarch64',
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
-                dockerNode         : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
-                additionalNodeLabels: [
-                        openj9:  'hw.arch.aarch64 && sw.os.linux'
-                ],
-                test                : 'default',
-                configureArgs       : [
-                        "hotspot" : '--enable-dtrace=auto',
-                        "openj9" : '--enable-dtrace=auto',
-                        "corretto" : '--enable-dtrace=auto',
-                        "dragonwell" : "--enable-dtrace=auto --with-extra-cflags=\"-march=armv8.2-a+crypto\" --with-extra-cxxflags=\"-march=armv8.2-a+crypto\"",
-                        "bisheng" : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server'
-                ]
+            os                  : 'linux',
+            arch                : 'aarch64',
+            dockerImage         : 'adoptopenjdk/centos7_build_image@sha256:e8ab3ee5aab3f78f88a39bacadbd4c9e87c7e2ff8fb7a9f7917427568ccf9ddd',
+            dockerNode         : 'sw.tool.docker',
+            dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
+            additionalNodeLabels: [
+                    openj9:  'hw.arch.aarch64 && sw.os.linux'
+            ],
+            test                : 'default',
+            configureArgs       : [
+                    "hotspot" : '--enable-dtrace=auto',
+                    "openj9" : '--enable-dtrace=auto --with-version-pre=ea --without-version-opt  --with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="11.0.12.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues',
+                    "corretto" : '--enable-dtrace=auto',
+                    "dragonwell" : "--enable-dtrace=auto --with-extra-cflags=\"-march=armv8.2-a+crypto\" --with-extra-cxxflags=\"-march=armv8.2-a+crypto\"",
+                    "bisheng" : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server'
+            ]
         ],
 
         x64LinuxXL    : [
-                os                   : 'linux',
-                dockerImage          : 'adoptopenjdk/centos6_build_image',
-                dockerFile: [
-                        openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
-                ],
-                arch                 : 'x64',
-                test                 : "default",
-                additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --enable-jitserver --enable-dtrace=auto'
+            os                   : 'linux',
+            dockerImage          : 'adoptopenjdk/centos6_build_image',
+            dockerFile: [
+                    openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
+            ],
+            arch                 : 'x64',
+            test                 : "default",
+            additionalFileNameTag: "linuxXL",
+            configureArgs        : '--with-noncompressedrefs --enable-jitserver --enable-dtrace=auto'
         ],
         s390xLinuxXL    : [
-                os                   : 'linux',
-                arch                 : 's390x',
-                test                 : 'default',
-                additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
+            os                   : 'linux',
+            arch                 : 's390x',
+            test                 : 'default',
+            additionalFileNameTag: "linuxXL",
+            configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
         ppc64leLinuxXL    : [
-                os                   : 'linux',
-                arch                 : 'ppc64le',
-                additionalNodeLabels : 'centos7',
-                test                 : 'default',
-                additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto --enable-jitserver'
+            os                   : 'linux',
+            arch                 : 'ppc64le',
+            additionalNodeLabels : 'centos7',
+            test                 : 'default',
+            additionalFileNameTag: "linuxXL",
+            configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto --enable-jitserver'
         ],
         aarch64LinuxXL    : [
-                os                   : 'linux',
-                dockerImage          : 'adoptopenjdk/centos7_build_image',
-                arch                 : 'aarch64',
-                test                 : 'default',
-                additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
+            os                   : 'linux',
+            dockerImage          : 'adoptopenjdk/centos7_build_image',
+            arch                 : 'aarch64',
+            test                 : 'default',
+            additionalFileNameTag: "linuxXL",
+            configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
         riscv64Linux      :  [
-                os                   : 'linux',
-                arch                 : 'riscv64',
-                dockerImage          : [
-                        "openj9"     : 'adoptopenjdk/centos6_build_image@sha256:19cdb5284da031aef7c73cb52ee7018502d65d0ca21cebc45d9652eec3926458',
-                        "bisheng"    : 'adoptopenjdk/centos6_build_image'
-                ],
-                dockerNode         : 'sw.tool.docker && sw.config.uid1000',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
-                crossCompile         : [
-                        "openj9"     : 'x64',
-                        "bisheng"    : 'x64'
-                ],
-                buildArgs            : [
-                        "openj9"     : '--cross-compile',
-                        "bisheng"    : '--cross-compile --branch risc-v'
-                ],
-                configureArgs        : [
-                        "openj9"     : '--disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root'
-                ],
-                test                 : false
+            os                   : 'linux',
+            arch                 : 'riscv64',
+            dockerImage          : [
+                    "openj9"     : 'adoptopenjdk/centos6_build_image@sha256:19cdb5284da031aef7c73cb52ee7018502d65d0ca21cebc45d9652eec3926458',
+                    "bisheng"    : 'adoptopenjdk/centos6_build_image'
+            ],
+            dockerNode         : 'sw.tool.docker && sw.config.uid1000',
+            dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
+            crossCompile         : [
+                    "openj9"     : 'x64',
+                    "bisheng"    : 'x64'
+            ],
+            buildArgs            : [
+                    "openj9"     : '--cross-compile',
+                    "bisheng"    : '--cross-compile --branch risc-v'
+            ],
+            configureArgs        : [
+                    "openj9"     : '--disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root'
+            ],
+            test                 : false
         ]
   ]
 

--- a/pipelines/jobs/configurations/jdk16u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16u_pipeline_config.groovy
@@ -6,16 +6,7 @@ class Config16 {
                 additionalNodeLabels: 'ci.project.openj9 && hw.arch.x86 && sw.os.osx.10_14',
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
-                configureArgs       : '--enable-dtrace'
-        ],
-
-        x64MacXL    : [
-                os                   : 'mac',
-                arch                 : 'x64',
-                additionalNodeLabels : 'macos10.14',
-                test                 : 'default',
-                additionalFileNameTag: "macosXL",
-                configureArgs        : '--with-noncompressedrefs --enable-dtrace'
+                configureArgs       : '--enable-dtrace --with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="16.0.2.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
         ],
 
         x64Linux  : [
@@ -24,7 +15,7 @@ class Config16 {
                 additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
                 dockerImage: [
                         hotspot     : 'adoptopenjdk/centos6_build_image',
-                        openj9      : 'adoptopenjdk/centos7_build_image'
+                        openj9      : 'adoptopenjdk/centos7_build_image@sha256:de97e2dd5655e73ddd47f32b3676dae0865aaeb735770b1b5e7fdf0c9bf92fef'
                 ],
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
@@ -37,31 +28,9 @@ class Config16 {
                         openj9      : '!(sw.os.cent.6||sw.os.rhel.6)'
                 ],
                 configureArgs       : [
-                        "openj9"      : '--enable-dtrace --enable-jitserver',
+                        "openj9"      : '--enable-dtrace --enable-jitserver --with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="16.0.2.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues',
                         "hotspot"     : '--enable-dtrace'
                 ]
-        ],
-
-        x64LinuxXL  : [
-                os                   : 'linux',
-                arch                 : 'x64',
-                dockerImage          : 'adoptopenjdk/centos7_build_image',
-                dockerFile: [
-                        openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
-                ],
-                test                 : 'default',
-                additionalTestLabels: [
-                        openj9      : '!(centos6||rhel6)'
-                ],
-                additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --enable-dtrace --enable-jitserver'
-        ],
-
-        x64AlpineLinux  : [
-                os                  : 'alpine-linux',
-                arch                : 'x64',
-                dockerImage         : 'adoptopenjdk/alpine3_build_image',
-                test                : 'default'
         ],
 
         x64Windows: [
@@ -69,39 +38,7 @@ class Config16 {
                 arch                : 'x64',
                 additionalNodeLabels: 'ci.project.openj9 && hw.arch.x86 && sw.os.windows',
                 cleanWorkspaceAfterBuild: true,
-                test                : 'default'
-        ],
-
-        x64WindowsXL: [
-                os                   : 'windows',
-                arch                 : 'x64',
-                additionalNodeLabels : 'win2012&&vs2017',
-                test                 : 'default',
-                additionalFileNameTag: "windowsXL",
-                configureArgs        : '--with-noncompressedrefs'
-        ],
-
-        // TODO: Enable testing (https://github.com/adoptium/ci-jenkins-pipelines/issues/77)
-        aarch64Windows: [
-                os                  : 'windows',
-                arch                : 'aarch64',
-                crossCompile        : 'x64',
-                buildArgs           : '--cross-compile',
-                additionalNodeLabels: 'win2016&&vs2019',
-                test                : [
-                        nightly: [],
-                        weekly : []
-                ]
-        ],
-
-
-        x32Windows: [
-                os                  : 'windows',
-                arch                : 'x86-32',
-                additionalNodeLabels: 'win2012&&vs2017',
-                buildArgs : [
-                        hotspot : '--jvm-variant client,server'
-                ],
+                configureArgs: '--with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="16.0.2.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-jdk-rc-name="IBM Semeru Runtime"',
                 test                : 'default'
         ],
 
@@ -114,7 +51,7 @@ class Config16 {
                 ],
                 test                : 'default',
                 configureArgs: [
-                        openj9: '--disable-ccache'
+                        openj9: '--disable-ccache --with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="16.0.2.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
                 ],
                 cleanWorkspaceAfterBuild: true
         ],
@@ -128,15 +65,7 @@ class Config16 {
                 additionalNodeLabels: [
                         openj9:  'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)'
                 ],
-                configureArgs       : '--enable-dtrace'
-        ],
-
-        s390xLinuxXL  : [
-                os                   : 'linux',
-                arch                 : 's390x',
-                test                 : 'default',
-                additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --enable-dtrace'
+                configureArgs       : '--enable-dtrace --with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="16.0.2.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
         ],
 
         ppc64leLinux    : [
@@ -150,24 +79,15 @@ class Config16 {
                 ],
                 configureArgs       : [
                         "hotspot"     : '--enable-dtrace',
-                        "openj9"      : '--enable-dtrace --enable-jitserver'
+                        "openj9"      : '--enable-dtrace --enable-jitserver --with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="16.0.2.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
                 ]
 
-        ],
-
-        ppc64leLinuxXL    : [
-                os                   : 'linux',
-                arch                 : 'ppc64le',
-                additionalNodeLabels : 'centos7',
-                test                 : 'default',
-                additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace'
         ],
 
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerImage         : 'adoptopenjdk/centos7_build_image@sha256:e8ab3ee5aab3f78f88a39bacadbd4c9e87c7e2ff8fb7a9f7917427568ccf9ddd',
                 dockerNode         : 'sw.tool.docker',
                 dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : 'default',
@@ -175,23 +95,7 @@ class Config16 {
                         openj9:  'hw.arch.aarch64 && sw.os.linux'
                 ],
                 test                : 'default',
-                configureArgs       : '--enable-dtrace'
-        ],
-
-        aarch64LinuxXL    : [
-                os                   : 'linux',
-                dockerImage          : 'adoptopenjdk/centos7_build_image',
-                arch                 : 'aarch64',
-                test                 : 'default',
-                additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --enable-dtrace'
-        ],
-
-        arm32Linux    : [
-                os                  : 'linux',
-                arch                : 'arm',
-                test                : 'default',
-                configureArgs       : '--enable-dtrace'
+                configureArgs       : '--enable-dtrace --with-version-pre=ea --without-version-opt --with-vendor-name="International Business Machines Corporation" --with-vendor-version-string="16.0.2.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
         ]
   ]
 

--- a/pipelines/jobs/configurations/jdk17_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17_pipeline_config.groovy
@@ -6,7 +6,7 @@ class Config17 {
                 additionalNodeLabels: 'ci.project.openj9 && hw.arch.x86 && sw.os.osx.10_14',
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
-                configureArgs       : '--enable-dtrace'
+                configureArgs       : '--enable-dtrace --with-vendor-name="IBM Corporation" --with-vendor-version-string="17.0.0.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
         ],
 
         x64MacXL    : [
@@ -37,7 +37,7 @@ class Config17 {
                         openj9      : '!(sw.os.cent.6||sw.os.rhel.6)'
                 ],
                 configureArgs       : [
-                        "openj9"      : '--enable-dtrace --enable-jitserver',
+                        "openj9"      : '--enable-dtrace --enable-jitserver --with-vendor-name="IBM Corporation" --with-vendor-version-string="17.0.0.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues',
                         "hotspot"     : '--enable-dtrace'
                 ]
         ],
@@ -69,6 +69,7 @@ class Config17 {
                 arch                : 'x64',
                 additionalNodeLabels: 'ci.project.openj9 && hw.arch.x86 && sw.os.windows',
                 cleanWorkspaceAfterBuild: true,
+                configureArgs: '--with-vendor-name="IBM Corporation" --with-vendor-version-string="17.0.0.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-jdk-rc-name="IBM Semeru Runtime"',
                 test                : 'default'
         ],
 
@@ -114,7 +115,7 @@ class Config17 {
                 ],
                 test                : 'default',
                 configureArgs : [
-                    openj9 : '--disable-ccache'
+                        openj9: '--disable-ccache --with-vendor-name="IBM Corporation" --with-vendor-version-string="17.0.0.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
                 ],
                 cleanWorkspaceAfterBuild: true
         ],
@@ -128,7 +129,7 @@ class Config17 {
                 additionalNodeLabels: [
                         openj9:  'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)'
                 ],
-                configureArgs : '--enable-dtrace'
+                configureArgs       : '--enable-dtrace --with-vendor-name="IBM Corporation" --with-vendor-version-string="17.0.0.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
         ],
 
         s390xLinuxXL  : [
@@ -150,7 +151,7 @@ class Config17 {
                 ],
                 configureArgs       : [
                         "hotspot"     : '--enable-dtrace',
-                        "openj9"      : '--enable-dtrace --enable-jitserver'
+                        "openj9"      : '--enable-dtrace --enable-jitserver --with-vendor-name="IBM Corporation" --with-vendor-version-string="17.0.0.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
                 ]
 
         ],
@@ -167,7 +168,7 @@ class Config17 {
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerImage         : 'adoptopenjdk/centos7_build_image@sha256:e8ab3ee5aab3f78f88a39bacadbd4c9e87c7e2ff8fb7a9f7917427568ccf9ddd',
                 dockerNode         : 'sw.tool.docker',
                 dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : 'default',
@@ -175,8 +176,7 @@ class Config17 {
                         openj9:  'hw.arch.aarch64 && sw.os.linux'
                 ],
                 test                : 'default',
-                cleanWorkspaceAfterBuild: true,
-                configureArgs       : '--enable-dtrace'
+                configureArgs       : '--enable-dtrace --with-version-pre=ea --without-version-opt --with-vendor-name="IBM Corporation" --with-vendor-version-string="17.0.0.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
         ],
 
         aarch64LinuxXL    : [

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -9,7 +9,7 @@ class Config8 {
                         openj9  : 'ci.project.openj9 && hw.arch.x86 && sw.os.osx.10_14'
                 ],
                 cleanWorkspaceAfterBuild: true,
-                configureArgs      : '--with-vendor-name="IBM Corporation" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues',
+                configureArgs      : '--with-vendor-name="International Business Machines Corporation" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues',
                 test                 : 'default'
         ],
 
@@ -26,7 +26,7 @@ class Config8 {
                 os                  : 'linux',
                 arch                : 'x64',
                 additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
-                dockerImage         : 'adoptopenjdk/centos6_build_image',
+                dockerImage         : 'adoptopenjdk/centos6_build_image@sha256:643fa990a41dbaf448a24b2e189e69ef9d06ef1cd077ca78208dab35a2d48a19',
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile',
                         dragonwell: 'pipelines/build/dockerFiles/dragonwell.dockerfile'
@@ -35,7 +35,7 @@ class Config8 {
                 dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                 : 'default',
                 configureArgs       : [
-                        "openj9"      : '--enable-jitserver --with-vendor-name="IBM Corporation" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues',
+                        "openj9"      : '--enable-jitserver --with-vendor-name="International Business Machines Corporation" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues',
                         "dragonwell"  : '--enable-unlimited-crypto --with-jvm-variants=server  --with-zlib=system',
                 ]
         ],
@@ -49,7 +49,7 @@ class Config8 {
                         openj9  : 'ci.project.openj9 && hw.arch.x86 && sw.os.windows',
                         dragonwell: 'win2012'
                 ],
-                configureArgs      : '--with-vendor-name="IBM Corporation" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-jdk-rc-name="IBM Semeru Platform"',
+                configureArgs      : '--with-vendor-name="International Business Machines Corporation" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-jdk-rc-name="IBM Semeru Runtime"',
                 test                 : 'default'
         ],
 
@@ -73,7 +73,7 @@ class Config8 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                configureArgs      : '--with-vendor-name="IBM Corporation" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-jdk-rc-name="IBM Semeru Platform"',
+                configureArgs      : '--with-vendor-name="International Business Machines Corporation" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-jdk-rc-name="IBM Semeru Runtime"',
                 test                 : 'default'
         ],
 
@@ -86,7 +86,7 @@ class Config8 {
                 ],
                 test                 : 'default',
                 configureArgs: [
-                    "openj9"        : '--disable-ccache --with-vendor-name="IBM Corporation" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
+                    "openj9"        : '--disable-ccache --with-vendor-name="International Business Machines Corporation" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
                 ],
                 cleanWorkspaceAfterBuild: true
         ],
@@ -98,7 +98,7 @@ class Config8 {
                 additionalNodeLabels: [
                         openj9:  'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)'
                 ],
-                configureArgs      : '--with-vendor-name="IBM Corporation" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues',
+                configureArgs      : '--with-vendor-name="International Business Machines Corporation" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues',
                 test: [
                         hotspot: ['sanity.openjdk'],
                         openj9: 'default'
@@ -127,7 +127,7 @@ class Config8 {
                         openj9:  'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)'
                 ],
                 configureArgs       : [
-                        "openj9"      : '--enable-jitserver --with-vendor-name="IBM Corporation" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
+                        "openj9"      : '--enable-jitserver --with-vendor-name="International Business Machines Corporation" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
                 ]
         ],
 
@@ -140,7 +140,7 @@ class Config8 {
         aarch64Linux  : [
                 os                  : 'linux',
                 arch                : 'aarch64',
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerImage         : 'adoptopenjdk/centos7_build_image@sha256:e8ab3ee5aab3f78f88a39bacadbd4c9e87c7e2ff8fb7a9f7917427568ccf9ddd',
                 dockerFile: [
                         dragonwell: 'pipelines/build/dockerFiles/dragonwell_aarch64.dockerfile'
                 ],
@@ -149,7 +149,7 @@ class Config8 {
                 additionalNodeLabels: [
                         openj9:  'hw.arch.aarch64 && sw.os.linux'
                 ],
-                configureArgs      : '--with-vendor-name="IBM Corporation" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues',
+                configureArgs      : '--with-milestone=ea --with-vendor-name="International Business Machines Corporation" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues',
                 cleanWorkspaceAfterBuild: true,
                 test                 : 'default'
         ],


### PR DESCRIPTION
Update downstream jobs configurations:
- add --with-version* options to configureArgs, update vendor and
product
- remove --with-jdk-rc-name from win8 config
- add special.jck to weekly testing

Update pipeline to support Semeru Certified and Open:
- update upstream job to create separate distribution packages for
Semeru Open and Certified
Add support for Semeru to the downstream jobs:
- update binaries name: replace OpenJDK* with ibm-semeru-*, add
javaToBuild to tarballs names for nightly builds
- remove installer job for Linux, replaced with RPM package pipeline
from upstream job
- replace eclipse-codesign sigh tool with ucl and set node labels for
sign job
- remove directory name from path for checksum files

Update job generator to exclude platforms with additionalFileNameTag.
Update command to generate the *sha256.txt without the leading directory
components from the binary path.

Co-authored-by: Adam Brousseau <adam.brousseau88@gmail.com>
Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>