### PR TITLE
Vary updates for RPM build

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -491,6 +491,8 @@ class Build {
                     // TODO: Archive Artifactory
                 }
             }
+        } else {
+            context.echo "Skip signing for unsupported OS: ${buildConfig.TARGET_OS}"
         }
     }
 

--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -4,7 +4,9 @@
         "build_url"          : "https://github.com/ibmruntimes/temurin-build.git",
         "build_branch"       : "ibm",
         "pipeline_url"       : "https://github.com/ibmruntimes/ci-jenkins-pipelines.git",
-        "pipeline_branch"    : "ibm"
+        "pipeline_branch"    : "ibm",
+        "installer_url"      : "git@github.ibm.com:runtimes/adoptium-installer.git",
+        "installer_branch"   : "ibm"
     },
     "jenkinsDetails"         : {
         "rootUrl"            : "https://hyc-runtimes-jenkins.swg-devops.com/",


### PR DESCRIPTION
Infer variant version and tag from overridePublishName
and pass them downstream to RPM build.
Fix targets filtering for RPM build.
Add installer repository URL and branch to defaults.json
for scm configuration.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>