### PR TITLE
Enable Semeru 18

### DIFF
--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -173,7 +173,7 @@ Map<String, ?> defaultTestConfigurations = [
     ]
 ]
 
-List<Integer> defaultJavaVersions = [8, 11, 16, 17]
+List<Integer> defaultJavaVersions = [8, 11, 16, 17, 18]
 
 return {
     String branch,

--- a/pipelines/jobs/configurations/jdk18.groovy
+++ b/pipelines/jobs/configurations/jdk18.groovy
@@ -1,0 +1,35 @@
+targetConfigurations = [
+    "x64Mac"      : [
+            "openj9"
+    ],
+    "x64Linux"    : [
+            "openj9"
+    ],
+    "x64Windows"  : [
+            "openj9"
+    ],
+    "ppc64Aix"    : [
+            "openj9"
+    ],
+    "ppc64leLinux": [
+            "openj9"
+    ],
+    "s390xLinux"  : [
+            "openj9"
+    ],
+    "aarch64Linux": [
+            "openj9"
+    ]
+]
+
+// 1:30 am Wed, Fri
+triggerSchedule_nightly="30 1 * * 3,5"
+// 11am Sat
+triggerSchedule_weekly="59 10 * * 6"
+
+// scmReferences to use for weekly release build
+weekly_release_scmReferences=[
+    "openj9"         : ""
+]
+
+return this

--- a/pipelines/jobs/configurations/jdk18_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk18_pipeline_config.groovy
@@ -1,0 +1,156 @@
+class Config18 {
+  final Map<String, Map<String, ?>> buildConfigurations = [
+        x64Mac    : [
+                os                  : 'mac',
+                arch                : 'x64',
+                additionalNodeLabels: 'ci.project.openj9 && hw.arch.x86 && sw.os.osx.10_14',
+                test                : 'default',
+                cleanWorkspaceAfterBuild: true,
+                configureArgs       : [
+                        hostspot    : '--enable-dtrace',
+                        openj9      : '--enable-dtrace --with-vendor-name="IBM Corporation" --with-vendor-version-string="18.0.0.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
+                ]
+        ],
+
+        x64Linux  : [
+                os                  : 'linux',
+                arch                : 'x64',
+                additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
+                dockerImage: [
+                        hotspot     : 'adoptopenjdk/centos6_build_image',
+                        openj9      : 'adoptopenjdk/centos7_build_image'
+                ],
+                dockerFile: [
+                        openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
+                ],
+                dockerNode          : 'sw.tool.docker && sw.config.uid1000',
+                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
+                test                : 'default',
+                cleanWorkspaceAfterBuild: true,
+                additionalTestLabels: [
+                        openj9      : '!(sw.os.cent.6||sw.os.rhel.6)'
+                ],
+                configureArgs       : [
+                        openj9      : '--enable-dtrace --enable-jitserver --with-vendor-name="IBM Corporation" --with-vendor-version-string="18.0.0.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues',
+                        hotspot     : '--enable-dtrace'
+                ]
+        ],
+
+        x64AlpineLinux  : [
+                os                  : 'alpine-linux',
+                arch                : 'x64',
+                dockerImage         : 'adoptopenjdk/alpine3_build_image',
+                test                : 'default'
+        ],
+
+        x64Windows: [
+                os                  : 'windows',
+                arch                : 'x64',
+                additionalNodeLabels: 'ci.project.openj9 && hw.arch.x86 && sw.os.windows',
+                test                : 'default'
+                cleanWorkspaceAfterBuild: true,
+                configureArgs       : [
+                        openj9      :'--with-vendor-name="IBM Corporation" --with-vendor-version-string="18.0.0.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-jdk-rc-name="IBM Semeru Runtime"'
+                ]
+        ],
+
+        // TODO: Enable testing (https://github.com/adoptium/ci-jenkins-pipelines/issues/77)
+        aarch64Windows: [
+                os                  : 'windows',
+                arch                : 'aarch64',
+                crossCompile        : 'x64',
+                buildArgs           : '--cross-compile',
+                additionalNodeLabels: 'win2016&&vs2019',
+                test                : [
+                        nightly: [],
+                        weekly : []
+                ]
+        ],
+
+        x32Windows: [
+                os                  : 'windows',
+                arch                : 'x86-32',
+                additionalNodeLabels: 'win2012&&vs2017',
+                buildArgs           : [
+                        hotspot : '--jvm-variant client,server'
+                ],
+                test                : 'default'
+        ],
+
+        ppc64Aix    : [
+                os                  : 'aix',
+                arch                : 'ppc64',
+                additionalNodeLabels: [
+                        hotspot: 'xlc16&&aix710',
+                        openj9:  'hw.arch.ppc64 && sw.os.aix.7_1'
+                ],
+                test                : 'default',
+                configureArgs : [
+                        openj9: '--disable-ccache --with-vendor-name="IBM Corporation" --with-vendor-version-string="18.0.0.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
+                ],
+                cleanWorkspaceAfterBuild: true
+        ],
+
+
+        s390xLinux    : [
+                os                  : 'linux',
+                arch                : 's390x',
+                test                : 'default',
+                cleanWorkspaceAfterBuild: true,
+                additionalNodeLabels: 'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)',
+                configureArgs       : [
+                        hotspot     : '--enable-dtrace',
+                        openj9      : '--enable-dtrace --with-vendor-name="IBM Corporation" --with-vendor-version-string="18.0.0.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
+                ]
+        ],
+
+        ppc64leLinux    : [
+                os                  : 'linux',
+                arch                : 'ppc64le',
+                additionalNodeLabels: 'centos7',
+                test                : 'default',
+                cleanWorkspaceAfterBuild: true,
+                additionalNodeLabels: 'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)',
+                configureArgs       : [
+                        hotspot     : '--enable-dtrace',
+                        openj9      : '--enable-dtrace --enable-jitserver --with-vendor-name="IBM Corporation" --with-vendor-version-string="18.0.0.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
+                ]
+
+        ],
+
+        aarch64Linux    : [
+                os                  : 'linux',
+                arch                : 'aarch64',
+                additionalNodeLabels: [
+                        openj9:  'hw.arch.aarch64 && sw.os.linux'
+                ],
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerNode         : 'sw.tool.docker',
+                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
+                test                : 'default',
+                configureArgs       : [
+                        hotspot     : '--enable-dtrace',
+                        openj9      : '--enable-dtrace --with-version-pre=ea --without-version-opt --with-vendor-name="IBM Corporation" --with-vendor-version-string="18.0.0.0" --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-vendor-url=https://www.ibm.com/ --with-vendor-bug-url=https://github.com/eclipse-openj9/openj9/issues --with-vendor-vm-bug-url=https://github.com/eclipse-openj9/openj9/issues'
+                ],
+                testDynamic         : false
+        ],
+
+        aarch64Mac: [
+                os                  : 'mac',
+                arch                : 'aarch64',
+                additionalNodeLabels: 'macos11',
+                test                : 'default'
+        ],
+
+        arm32Linux    : [
+                os                  : 'linux',
+                arch                : 'arm',
+                test                : 'default',
+                configureArgs       : '--enable-dtrace'
+        ]
+  ]
+
+}
+
+Config18 config = new Config18()
+return config.buildConfigurations


### PR DESCRIPTION
Update jdk18 configuration files for upstream and downstream pipelines
for openj9 variant.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>