### PR TITLE
Add support for numMachine per test for dynamic parallel testing

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -116,8 +116,10 @@ class Builder implements Serializable {
         }
 
         def testList = getTestList(platformConfig, variant)
-        def dynamicList = getDynamicParams(platformConfig, variant).get("testLists")
-        def numMachines = getDynamicParams(platformConfig, variant).get("numMachines")
+
+        def dynamicTestsParameters = getDynamicParams(platformConfig, variant)
+        def dynamicList = dynamicTestsParameters.get("testLists")
+        def numMachines = dynamicTestsParameters.get("numMachines")
 
         def platformCleanWorkspaceAfterBuild = getCleanWorkspaceAfterBuild(platformConfig)
 
@@ -263,27 +265,58 @@ class Builder implements Serializable {
         return testList
     }
     /*
-    Get the list of tests to dynamically run  parallel builds from the build configurations.
+    Get the list of tests to dynamically run parallel builds from the build configurations.
     This function parses and applies this to the individual build config.
     */
     Map<String, ?> getDynamicParams(Map<String, ?> configuration, String variant) {
-        List<String> testLists = DEFAULTS_JSON["testDetails"]["defaultDynamicParas"]["testLists"]
-        String numMachines = DEFAULTS_JSON["testDetails"]["defaultDynamicParas"]["numMachines"]
+        List<String> testLists = []
+        List<String> numMachines = []
+
+        def testDynamicMap
+
         if (configuration.containsKey("testDynamic")) {
-            if (configuration.get("testDynamic")) {
-                if(configuration.get("testDynamic").containsKey(variant)) {
-                    testLists = configuration.get("testDynamic").get(variant).get("testLists")
-                    numMachines = configuration.get("testDynamic").get(variant).get("numMachines")
-                } else {
-                    testLists = configuration.get("testDynamic").get("testLists")
-                    numMachines = configuration.get("testDynamic").get("numMachines")
+            // fetch from buildConfigurations for target
+
+            // testDynamic could be map, list or boolean
+            if (configuration.containsKey("testDynamic") && configuration.get("testDynamic")) {
+                // fetch variant options
+                testDynamicMap = configuration.get("testDynamic").get(variant)
+            } else {
+                // fetch generic options
+                testDynamicMap = configuration.get("testDynamic")
+            }
+        } else if (DEFAULTS_JSON["testDetails"]["defaultDynamicParas"]) {
+            // fetch default options
+            testDynamicMap = DEFAULTS_JSON["testDetails"]["defaultDynamicParas"]
+        }
+
+        if (testDynamicMap.containsKey("testLists")) {
+            testLists.addAll(testDynamicMap.get("testLists"))
+        }
+
+        if (testDynamicMap.containsKey("numMachines")) {
+            // populate the list of number of machines per tests
+            if (List.class.isInstance(testDynamicMap.get("numMachines"))) {
+                // the size of the numMachines List should match the testLists size
+                // otherwize throw an error
+                // e.g. 
+                // testLists    = ['extended.openjdk', 'extended.jck', 'special.jck']
+                // numMachines  = ['3',                '2',            '5']
+
+                numMachines.addAll(testDynamicMap.get("numMachines"))
+
+                if (numMachines.size() < testLists.size()) {
+                    throw new Exception("Configuration error for dynamic testing: missmatch between dymanic parallel test targets testListing: ${testListing} and numMachines: ${numMachines}")
                 }
-           } else {
-                testLists = []
-                numMachines = ""
+            } else {
+                if (!testLists.isEmpty()) {
+                    // work-around for numMachines as a String
+                    // populate the List<String> number of machines with duplicates
+                    numMachines.addAll(Collections.nCopies(testLists.size(), "${testDynamicMap.get('numMachines')}"))
+                }
             }
         }
-        
+
         return ["testLists": testLists, "numMachines": numMachines]
     }
     /*

--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -338,7 +338,7 @@ class Regeneration implements Serializable {
     */
     Map<String, ?> getDynamicParams() {
         List<String> testLists = DEFAULTS_JSON["testDetails"]["defaultDynamicParas"]["testLists"]
-        String numMachines = DEFAULTS_JSON["testDetails"]["defaultDynamicParas"]["numMachines"]
+        List<String> numMachines = DEFAULTS_JSON["testDetails"]["defaultDynamicParas"]["numMachines"]
         return ["testLists": testLists, "numMachines": numMachines]
     }
     /*

--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -112,6 +112,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                 <dt><strong>PUBLISH_NAME</strong></dt><dd>Set name of publish</dd>
                 <dt><strong>ADOPT_BUILD_NUMBER</strong></dt><dd>Adopt build number</dd>
                 <dt><strong>ENABLE_TESTS</strong></dt><dd>Run tests</dd>
+                <dt><strong>ENABLE_TESTDYNAMICPARALLEL</strong></dt><dd>Run parallel</dd>
                 <dt><strong>ENABLE_INSTALLERS</strong></dt><dd>Run installers</dd>
                 <dt><strong>ENABLE_SIGNER</strong></dt><dd>Run signer</dd>
                 <dt><strong>CLEAN_WORKSPACE</strong></dt><dd>Wipe out workspace before build</dd>

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -315,7 +315,10 @@ class Build {
 
         List testList = buildConfig.TEST_LIST
         List dynamicList = buildConfig.DYNAMIC_LIST
-        String numMachines = buildConfig.NUM_MACHINES
+        List numMachines = buildConfig.NUM_MACHINES
+        def enableTestDynamicParallel = Boolean.valueOf(buildConfig.ENABLE_TESTDYNAMICPARALLEL)
+        def numMachinesPerTest = ''
+
         testList.each { testType ->
 
             // For each requested test, i.e 'sanity.openjdk', 'sanity.system', 'sanity.perf', 'sanity.external', call test job
@@ -331,9 +334,19 @@ class Build {
 
                         def jobParams = getAQATestJobParams(testType)
                         def parallel = 'None'
-                        if (dynamicList.contains(testType)) {
+
+                        if (enableTestDynamicParallel && dynamicList.contains(testType)) {
+                            numMachinesPerTest = numMachines.getAt(dynamicList.indexOf(testType))
+                            if (!numMachinesPerTest) {
+                                // see build configuration in jdk*_pipeline_config.groovy
+                                // when numMachines is an array, its size should match the testLists size
+                                throw new Exception("No number of machines provided for running ${testType} tests in parallel, numMachines: ${numMachines}!")
+                            }
+                            context.println "Number of machines for running parallel tests: ${numMachinesPerTest}"
+
                             parallel = 'Dynamic'
                         }
+
                         def jobName = jobParams.TEST_JOB_NAME
                         def JobHelper = context.library(identifier: 'openjdk-jenkins-helper@master').JobHelper
 
@@ -361,7 +374,7 @@ class Build {
                                             context.string(name: 'LABEL_ADDITION', value: additionalTestLabel),
                                             context.string(name: 'KEEP_REPORTDIR', value: "${keep_test_reportdir}"),
                                             context.string(name: 'PARALLEL', value: parallel),
-                                            context.string(name: 'NUM_MACHINES', value: numMachines),
+                                            context.string(name: 'NUM_MACHINES', value: "${numMachinesPerTest}"),
                                             context.string(name: 'ACTIVE_NODE_TIMEOUT', value: "${buildConfig.ACTIVE_NODE_TIMEOUT}")]
                         }
                     }

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -206,6 +206,7 @@ node('master') {
         }
 
         config.put("enableTests", DEFAULTS_JSON['testDetails']['enableTests'] as Boolean)
+        config.put("enableTestDynamicParallel", DEFAULTS_JSON['testDetails']['enableTestDynamicParallel'] as Boolean)
 
         println "[INFO] JDK${javaVersion}: nightly pipelineSchedule = ${config.pipelineSchedule}"
 

--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -60,7 +60,7 @@
         "defaultDynamicParas": {
             "testLists"      : ["extended.openjdk"],
             "numMachines"    : "3"
-         }
+        }
     },
     "importLibraryScript"    : "pipelines/build/common/import_lib.groovy",
     "defaultsUrl"            : "https://raw.githubusercontent.com/ibmruntimes/ci-jenkins-pipelines/ibm/pipelines/defaults.json"

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -3,7 +3,7 @@ import groovy.json.JsonOutput
 gitRefSpec = ""
 propagateFailures = true
 runTests = enableTests
-runParallel = true
+runParallel = enableTestDynamicParallel
 runInstaller = true
 runSigner = true
 cleanWsBuildOutput = true

--- a/pipelines/library/src/common/IndividualBuildConfig.groovy
+++ b/pipelines/library/src/common/IndividualBuildConfig.groovy
@@ -10,7 +10,7 @@ class IndividualBuildConfig implements Serializable {
     final String JAVA_TO_BUILD
     final List<String> TEST_LIST
     final List<String> DYNAMIC_LIST
-    final String NUM_MACHINES
+    final List<String> NUM_MACHINES
     final String SCM_REF
     final String BUILD_ARGS
     final String NODE_LABEL
@@ -33,6 +33,7 @@ class IndividualBuildConfig implements Serializable {
     final String PUBLISH_NAME
     final String ADOPT_BUILD_NUMBER
     final boolean ENABLE_TESTS
+    final boolean ENABLE_TESTDYNAMICPARALLEL
     final boolean ENABLE_INSTALLERS
     final boolean ENABLE_SIGNER
     final boolean CLEAN_WORKSPACE
@@ -63,8 +64,16 @@ class IndividualBuildConfig implements Serializable {
             DYNAMIC_LIST = map.get("DYNAMIC_LIST")
         } else {
             DYNAMIC_LIST = []
-        }        
-        NUM_MACHINES = map.get("NUM_MACHINES")
+        }
+
+        if (String.class.isInstance(map.get("NUM_MACHINES"))) {
+            NUM_MACHINES = map.get("NUM_MACHINES").split(",")
+        } else if (List.class.isInstance(map.get("NUM_MACHINES"))) {
+            NUM_MACHINES = map.get("NUM_MACHINES")
+        } else {
+            NUM_MACHINES = []
+        }
+
         SCM_REF = map.get("SCM_REF")
         BUILD_ARGS = map.get("BUILD_ARGS")
         NODE_LABEL = map.get("NODE_LABEL")
@@ -87,6 +96,7 @@ class IndividualBuildConfig implements Serializable {
         PUBLISH_NAME = map.get("PUBLISH_NAME")
         ADOPT_BUILD_NUMBER = map.get("ADOPT_BUILD_NUMBER")
         ENABLE_TESTS = map.get("ENABLE_TESTS")
+        ENABLE_TESTDYNAMICPARALLEL = map.get("ENABLE_TESTDYNAMICPARALLEL")
         ENABLE_INSTALLERS = map.get("ENABLE_INSTALLERS")
         ENABLE_SIGNER = map.get("ENABLE_SIGNER")
         CLEAN_WORKSPACE = map.get("CLEAN_WORKSPACE")
@@ -140,6 +150,7 @@ class IndividualBuildConfig implements Serializable {
                 PUBLISH_NAME              : PUBLISH_NAME,
                 ADOPT_BUILD_NUMBER        : ADOPT_BUILD_NUMBER,
                 ENABLE_TESTS              : ENABLE_TESTS,
+                ENABLE_TESTDYNAMICPARALLEL: ENABLE_TESTDYNAMICPARALLEL,
                 ENABLE_INSTALLERS         : ENABLE_INSTALLERS,
                 ENABLE_SIGNER             : ENABLE_SIGNER,
                 CLEAN_WORKSPACE           : CLEAN_WORKSPACE,


### PR DESCRIPTION
Update upstream and downtream jobs to suport numMachines per test
targets.
Update the job generator to infer the parallel tests flag from job
configuration.
Propagate enableTestDynamicParallel flag downstream.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>