### PR TITLE
Fix to ensure Certified bins doesn't get named like Open Edition

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1082,7 +1082,7 @@ class Build {
 
         if (overrideFileNameVersion) {
             fileName = "${fileName}_${overrideFileNameVersion}"
-        } else if (buildConfig.PUBLISH_NAME) {
+        } else if ((buildConfig.PUBLISH_NAME) && (additionalFileNameTag != "IBM")) {
 
             // for java 11 remove jdk- and +. i.e jdk-11.0.3+7 -> 11.0.3_7_openj9-0.14.0
             def nameTag = buildConfig.PUBLISH_NAME


### PR DESCRIPTION
Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>