### PR TITLE
Add AIX installer and sign downstream builds

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -740,6 +740,7 @@ class Builder implements Serializable {
                     parameters: [
                         ['$class': 'BooleanParameterValue', name: 'RELEASE', value: release],
                         context.string(name: 'JDK_VERSION', value: "${getJavaVersionNumber()}"),
+                        context.string(name: 'PACKAGE_TYPE', value: 'srpm'),
                         context.string(name: 'PRODUCT', value: (tag ?: '')),
                         context.string(name: 'VARIANT', value: variant),
                         context.string(name: 'VARIANT_VERSION', value: variantVersion),


### PR DESCRIPTION
Enable installer and installer sign builds for AIX.
Add downstream builds to:
- build the RPM distribution package
- sign the RPM package

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>