### PR TITLE
Job generation customization

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -856,6 +856,17 @@ class Builder implements Serializable {
                 javaToBuild = "jdk"
             }
 
+            def userRemoteConfigs = ''
+
+            if (!useAdoptShellScripts) {
+                def userRemoteConfigsMap = [
+                    "branch": DEFAULTS_JSON['repository']['pipeline_branch'],
+                    "remotes": ["url": DEFAULTS_JSON['repository']['pipeline_url']]
+                ]
+
+                userRemoteConfigs = JsonOutput.prettyPrint(JsonOutput.toJson(userRemoteConfigsMap))
+            }
+
             context.echo "Java: ${javaToBuild}"
             context.echo "OS: ${targetConfigurations}"
             context.echo "Enable tests: ${enableTests}"
@@ -869,6 +880,7 @@ class Builder implements Serializable {
             context.echo "Tag/Branch name: ${scmReference}"
             context.echo "Keep test reportdir: ${keepTestReportDir}"
             context.echo "Keep release logs: ${keepReleaseLogs}"
+
 
             jobConfigurations.each { configuration ->
                 jobs[configuration.key] = {
@@ -887,11 +899,23 @@ class Builder implements Serializable {
                         context.stage(configuration.key) {
                             context.echo "Created job " + downstreamJobName
 
+                            // set downstream job parameters
+                            // add BUILD_CONFIGURATION
+                            def downstreamJobParams = config.toBuildParams()
+
+                            // add other parameters
+                            // pass user set values from the upstream job to the downstream job 
+                            // it allows customization without job regeneration (for developer builds)
+                            downstreamJobParams.add(['$class': 'TextParameterValue', name: 'USER_REMOTE_CONFIGS', value: userRemoteConfigs])
+                            downstreamJobParams.add(['$class': 'TextParameterValue', name: 'DEFAULTS_JSON', value: JsonOutput.prettyPrint(JsonOutput.toJson(DEFAULTS_JSON))])
+                            downstreamJobParams.add(context.string(name: 'SCM_REPO', value: (env.SCM_REPO) ?: DEFAULTS_JSON['repository']['pipeline_url']))
+                            downstreamJobParams.add(context.string(name: 'SCM_BRANCH', value: (env.SCM_BRANCH) ?: DEFAULTS_JSON['repository']['pipeline_branch']))
+
                             //TODO: remove parameters
-                            context.echo "with parameters: ${config.toBuildParams()}"
+                            context.echo "with parameters: ${downstreamJobParams}"
 
                             // execute build
-                            def downstreamJob = context.build job: downstreamJobName, propagate: false, parameters: config.toBuildParams()
+                            def downstreamJob = context.build job: downstreamJobName, propagate: false, parameters: downstreamJobParams
 
                             if (downstreamJob.getResult() == 'SUCCESS') {
                                 // copy artifacts from build

--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -40,11 +40,11 @@ pipelineJob("$buildFolder/$JOB_NAME") {
             scm {
                 git {
                     remote {
-                        url(GIT_URL)
+                        url('$SCM_REPO')
                         refspec(" +refs/pull/*:refs/remotes/origin/pr/* +refs/heads/master:refs/remotes/origin/master +refs/heads/*:refs/remotes/origin/*")
                         credentials("${CHECKOUT_CREDENTIALS}")
                     }
-                    branch("${GIT_BRANCH}")
+                    branch('$SCM_BRANCH')
                     extensions {
                         //repo clean is performed after scm checkout in pipelines/build/common/openjdk_build_pipeline.groovy
                         pruneStaleBranch()
@@ -135,5 +135,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
         if (binding.hasVariable('CUSTOM_BASEFILE_LOCATION')) {
             stringParam('CUSTOM_BASEFILE_LOCATION', "$CUSTOM_BASEFILE_LOCATION")
         }
+        stringParam('SCM_REPO', "${GIT_URL}", "The URL of the SCM repository hosting the pipeline Groovy scripts.")
+        stringParam('SCM_BRANCH', "${BRANCH}", "The  SCM branch.")
     }
 }

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -141,12 +141,27 @@ node('master') {
       def response = JobHelper.getAvailableReleases(this)
       int headVersion = (int) response.getAt("tip_version")
 
+      def javaVersions = (params.JAVA_VERSION) ? params.JAVA_VERSION.trim().replaceAll("\\s","").tokenize(',') : []
+      echo "javaVersions = ${javaVersions}"
+
       (8..headVersion+1).each({javaVersion ->
 
         if (retiredVersions.contains(javaVersion)) {
           println "[INFO] $javaVersion is a retired version that isn't currently built. Skipping generation..."
           return
         }
+
+        // allow selective regeneration
+        // if javaVersions is an empty list, generate all pipelines
+        // otherwize generate only pipelines for given JAVA_VERSION
+        if (!javaVersions.isEmpty() && !javaVersions.contains("${javaVersion}".trim())) {
+            // skip
+            println "[INFO] Skipping generation for ${javaVersion} (not in user's selection)..."
+            return
+        }
+
+        def suffix = (params.JOB_NAME_SUFFIX) ?: ''
+        def jobName = "openjdk${javaVersion}-pipeline${suffix}"
 
         def config = [
           TEST                : false,
@@ -155,7 +170,7 @@ node('master') {
           BUILD_FOLDER        : jobRoot,
           CHECKOUT_CREDENTIALS: checkoutCreds,
           JAVA_VERSION        : javaVersion,
-          JOB_NAME            : "openjdk${javaVersion}-pipeline",
+          JOB_NAME            : jobName,
           SCRIPT              : "${scriptFolderPath}/openjdk_pipeline.groovy",
           disableJob          : false,
           pipelineSchedule    : "0 0 31 2 0", // 31st Feb, so will never run,
@@ -188,7 +203,21 @@ node('master') {
           }
         }
 
-        config.put("targetConfigurations", target.targetConfigurations)
+        // map of targetConfigurations to exclude from builds
+        def excludes = (params.EXCLUDES_LIST) ?: ''
+        def buildTargetConfigurations = [:]
+
+        if (excludes) {
+            // remove excluded targets from targetConfigurations
+            def excludedTargetConfigurations = new JsonSlurper().parseText(excludes) as Map
+
+            println "[INFO] Excluding targetConfigurations: ${excludedTargetConfigurations} "
+            buildTargetConfigurations.putAll(target.targetConfigurations.minus(excludedTargetConfigurations))
+        } else {
+            buildTargetConfigurations.putAll(target.targetConfigurations)
+        }
+
+        config.put("targetConfigurations", buildTargetConfigurations)
 
         // hack as jenkins groovy does not seem to allow us to check if disableJob exists
         try {
@@ -205,7 +234,7 @@ node('master') {
           config.put("adoptScripts", true)
         }
 
-        config.put("enableTests", DEFAULTS_JSON['testDetails']['enableTests'] as Boolean)
+        config.put("enableTests", (params.containsKey('ENABLE_TESTS')) ? params.ENABLE_TESTS : DEFAULTS_JSON['testDetails']['enableTests'] as Boolean)
         config.put("enableTestDynamicParallel", DEFAULTS_JSON['testDetails']['enableTestDynamicParallel'] as Boolean)
 
         config.put("enableInstallers", (params.containsKey('ENABLE_INSTALLERS')) ? params.ENABLE_INSTALLERS : DEFAULTS_JSON['enableInstallers'] as Boolean)
@@ -236,7 +265,7 @@ node('master') {
         generatedPipelines.add(config["JOB_NAME"])
 
         // Create weekly release pipeline
-        config.JOB_NAME = "weekly-openjdk${javaVersion}-pipeline"
+        config.JOB_NAME = "weekly-${jobName}"
         config.SCRIPT = (params.WEEKLY_SCRIPT_PATH) ?: DEFAULTS_JSON['scriptDirectories']['weekly']
         if (!fileExists(config.SCRIPT)) {
           println "[WARNING] ${config.SCRIPT} does not exist in your chosen repository. Updating it to use Adopt's instead"

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -10,7 +10,7 @@ runSrcRpm = enableSourceRpm
 runVerifySigner = verifySigner
 cleanWsBuildOutput = true
 jdkVersion = "${JAVA_VERSION}"
-isLightweight = true
+isLightweight = false
 
 // if true means this is running in the pr builder pipeline
 if (binding.hasVariable('PR_BUILDER')) {
@@ -23,7 +23,6 @@ if (binding.hasVariable('PR_BUILDER')) {
     runSigner = false
     runSrcRpm = false
     runVerifySigner = false
-    isLightweight = false
 }
 
 if (!binding.hasVariable('disableJob')) {
@@ -40,11 +39,11 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
             scm {
                 git {
                     remote {
-                        url("${GIT_URL}")
+                        url('$SCM_REPO')
                         refspec(gitRefSpec)
                         credentials("${CHECKOUT_CREDENTIALS}")
                     }
-                    branch("${BRANCH}")
+                    branch('$SCM_BRANCH')
                 }
             }
             scriptPath(SCRIPT)
@@ -118,5 +117,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         stringParam('adoptBuildNumber', "", "Empty by default. If you ever need to re-release then bump this number. Currently this is only added to the build metadata file.")
         textParam('defaultsJson', JsonOutput.prettyPrint(JsonOutput.toJson(defaultsJson)), '<strong>DO NOT ALTER THIS PARAM UNLESS YOU KNOW WHAT YOU ARE DOING!</strong> This passes down the user\'s default constants to the downstream jobs.')
         textParam('adoptDefaultsJson', JsonOutput.prettyPrint(JsonOutput.toJson(adoptDefaultsJson)), '<strong>DO NOT ALTER THIS PARAM UNDER ANY CIRCUMSTANCES!</strong> This passes down adopt\'s default constants to the downstream jobs. NOTE: <code>defaultsJson</code> has priority, the constants contained within this param will only be used as a failsafe.')
+        stringParam('SCM_REPO', "${GIT_URL}", "The URL of the SCM repository hosting the pipeline Groovy scripts.")
+        stringParam('SCM_BRANCH', "${BRANCH}", "The  SCM branch.")
     }
 }


### PR DESCRIPTION
Add support for targets exclusion.
Customize job name for upstream pipelines.
Add scm parameters to upstream and downstream jobs.
Allow on demand pipeline generation based on version.
Pass downstream SCM_REPO, SCM_BRANCH, USER_REMOTE_CONFIGS and
DEFAULTS_JSON.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>