### PR TITLE
Add flags to enable/disable srpm and verify sign build

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -42,6 +42,8 @@ class Builder implements Serializable {
     boolean enableTestDynamicParallel
     boolean enableInstallers
     boolean enableSigner
+    boolean enableSourceRpm
+    boolean verifySigner
     boolean publish
     boolean release
     String releaseType
@@ -710,7 +712,7 @@ class Builder implements Serializable {
     Create SRPM for Linux platforms
     */
     def packageSourceBinaries(variant, tag, linuxTargets, installerUrl, installerBranch) { 
-        context.stage("package") {
+        context.stage("Source RPM") {
             def downstreamJobName = 'build-scripts/release/package_binaries'
             context.echo "build name: ${downstreamJobName} for ${linuxTargets}"
 
@@ -776,7 +778,7 @@ class Builder implements Serializable {
                         // archive artifacts
                         try {
                             context.timeout(time: pipelineTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT, unit: "HOURS") {
-                                context.archiveArtifacts artifacts: "target/**"
+                                context.archiveArtifacts artifacts: "**/*.src.rpm, **/*.src.rpm.sha256.txt"
                             }
                         } catch (FlowInterruptedException e) {
                             throw new Exception("[ERROR] Archive RPM artifact timeout (${pipelineTimeouts.ARCHIVE_ARTIFACTS_TIMEOUT} HOURS) has been reached. Exiting...")
@@ -799,11 +801,17 @@ class Builder implements Serializable {
     def verifySignatures() {
         context.stage("verify") {
             def downstreamJobName = 'build-scripts/release/check_sign_build'
+            def osList = jobConfigurations.collect({ it.value.TARGET_OS }).unique()
+            def archList = jobConfigurations.collect({ it.value.ARCHITECTURE }).unique()
+
+            context.echo "build name ${downstreamJobName} for OS: ${osList} and ARCH: ${archList}"
 
             def downstreamJob = context.build job: downstreamJobName,
                 parameters: [
                     ['$class': 'BooleanParameterValue', name: 'ENABLE_INSTALLERS', value: enableInstallers],
                     context.string(name: 'JDK_VERSION', value: "${getJavaVersionNumber()}"),
+                    context.string(name: 'OS', value: osList.join(',')),
+                    context.string(name: 'ARCH', value: archList.join(',')),
                     context.string(name: 'UPSTREAM_JOB_NAME', value: env.JOB_NAME),
                     context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${currentBuild.getNumber()}"),
                     context.string(name: 'SCM_REPO', value: (DEFAULTS_JSON['repository']['installer_url'] ?: '')),
@@ -853,6 +861,8 @@ class Builder implements Serializable {
             context.echo "Enable tests: ${enableTests}"
             context.echo "Enable Installers: ${enableInstallers}"
             context.echo "Enable Signer: ${enableSigner}"
+            context.echo "Enable Source RPM: ${enableSourceRpm}"
+            context.echo "Verify Signer: ${verifySigner}"
             context.echo "Use Adopt's Scripts: ${useAdoptShellScripts}"
             context.echo "Publish: ${publish}"
             context.echo "Release: ${release}"
@@ -952,7 +962,7 @@ class Builder implements Serializable {
             }
             context.parallel jobs
 
-            if (enableInstallers && (!linuxTargets.isEmpty() || !taggedLinuxTargets.isEmpty())) {
+            if (enableSourceRpm && (!linuxTargets.isEmpty() || !taggedLinuxTargets.isEmpty())) {
                 //build RedHat source RPM package for Linux platforms
                 //launch two downstream builds when current build also contains custom targets
                 def variant = jobConfigurations.collect({ it.value.VARIANT }).unique().get(0)
@@ -981,15 +991,20 @@ class Builder implements Serializable {
                 }
             }
 
-            if (enableSigner) {
-                try {
-                    context.timeout(time: pipelineTimeouts.PUBLISH_ARTIFACTS_TIMEOUT, unit: "HOURS") {
-                        verifySignatures()
+            if (verifySigner) {
+                if (enableSigner) {
+                    try {
+                        context.timeout(time: pipelineTimeouts.PUBLISH_ARTIFACTS_TIMEOUT, unit: "HOURS") {
+                            verifySignatures()
+                        }
+                    }catch (FlowInterruptedException e) {
+                        throw new Exception("[ERROR] Code sign verification timeout (${pipelineTimeouts.PUBLISH_ARTIFACTS_TIMEOUT} HOURS) has been reached OR the downstream job failed. Exiting...")
                     }
-                }catch (FlowInterruptedException e) {
-                    throw new Exception("[ERROR] Code sign verification timeout (${pipelineTimeouts.PUBLISH_ARTIFACTS_TIMEOUT} HOURS) has been reached OR the downstream job failed. Exiting...")
+                } else {
+                    context.println "Not verifying release signature!"
                 }
             }
+
             // publish to github if needed
             // Dont publish release automatically
             if (publish && !release) {
@@ -1020,6 +1035,8 @@ return {
     String enableTestDynamicParallel,
     String enableInstallers,
     String enableSigner,
+    String enableSourceRpm,
+    String verifySigner,
     String releaseType,
     String scmReference,
     String overridePublishName,
@@ -1075,6 +1092,8 @@ return {
             enableTestDynamicParallel: Boolean.parseBoolean(enableTestDynamicParallel),
             enableInstallers: Boolean.parseBoolean(enableInstallers),
             enableSigner: Boolean.parseBoolean(enableSigner),
+            enableSourceRpm: Boolean.parseBoolean(enableSourceRpm),
+            verifySigner: Boolean.parseBoolean(verifySigner),
             publish: publish,
             release: release,
             releaseType: releaseType,

--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -120,6 +120,8 @@ if (scmVars != null || configureBuild != null || buildConfigurations != null) {
         enableTestDynamicParallel,
         enableInstallers,
         enableSigner,
+        enableSourceRpm,
+        verifySigner,
         releaseType,
         scmReference,
         overridePublishName,

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -208,6 +208,11 @@ node('master') {
         config.put("enableTests", DEFAULTS_JSON['testDetails']['enableTests'] as Boolean)
         config.put("enableTestDynamicParallel", DEFAULTS_JSON['testDetails']['enableTestDynamicParallel'] as Boolean)
 
+        config.put("enableInstallers", (params.containsKey('ENABLE_INSTALLERS')) ? params.ENABLE_INSTALLERS : DEFAULTS_JSON['enableInstallers'] as Boolean)
+        config.put("enableSigner", (params.containsKey('ENABLE_SIGNER')) ? params.ENABLE_SIGNER : DEFAULTS_JSON['enableSigner'] as Boolean)
+        config.put("enableSourceRpm", (params.containsKey('ENABLE_SOURCE_RPM')) ? params.ENABLE_INSTALLERS : DEFAULTS_JSON['enableSourceRpm'] as Boolean)
+        config.put("verifySigner", (params.containsKey('VERIFY_SIGNER')) ? params.ENABLE_SIGNER : DEFAULTS_JSON['enableSigner'] as Boolean)
+
         println "[INFO] JDK${javaVersion}: nightly pipelineSchedule = ${config.pipelineSchedule}"
 
         config.put("defaultsJson", DEFAULTS_JSON)

--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -62,6 +62,10 @@
             "numMachines"    : ["3", "3", "3", "3", "5", "4", "8"]
         }
     },
+    "enableInstallers"       : true,
+    "enableSourceRpm"        : true,
+    "enableSigner"           : true,
+    "verifySigner"           : true,
     "importLibraryScript"    : "pipelines/build/common/import_lib.groovy",
     "defaultsUrl"            : "https://raw.githubusercontent.com/ibmruntimes/ci-jenkins-pipelines/ibm/pipelines/defaults.json"
 }

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -4,8 +4,10 @@ gitRefSpec = ""
 propagateFailures = true
 runTests = enableTests
 runParallel = enableTestDynamicParallel
-runInstaller = true
-runSigner = true
+runInstaller = enableInstallers
+runSigner = enableSigner
+runSrcRpm = enableSourceRpm
+runVerifySigner = verifySigner
 cleanWsBuildOutput = true
 jdkVersion = "${JAVA_VERSION}"
 isLightweight = true
@@ -19,6 +21,8 @@ if (binding.hasVariable('PR_BUILDER')) {
     runParallel = true
     runInstaller = false
     runSigner = false
+    runSrcRpm = false
+    runVerifySigner = false
     isLightweight = false
 }
 
@@ -99,6 +103,8 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         booleanParam('enableTestDynamicParallel', runParallel, 'If set to true test will be run parallel')
         booleanParam('enableInstallers', runInstaller, 'If set to true the installer pipeline will be executed')
         booleanParam('enableSigner', runSigner, 'If set to true the signer pipeline will be executed')
+        booleanParam('enableSourceRpm', runSrcRpm, 'If set to true the source RPM pipeline will be executed')
+        booleanParam('verifySigner', runVerifySigner, 'If set to true the check signer pipeline will be executed')
         stringParam('additionalConfigureArgs', "", "Additional arguments that will be ultimately passed to OpenJDK's <code>./configure</code>")
         stringParam('additionalBuildArgs', "", "Additional arguments to be passed to <code>makejdk-any-platform.sh</code>")
         stringParam('overrideFileNameVersion', "", "When forming the filename, ignore the part of the filename derived from the publishName or timestamp and override it.<br/>For instance if you set this to 'FOO' the final file name will be of the form: <code>OpenJDK8U-jre_ppc64le_linux_openj9_FOO.tar.gz</code>")


### PR DESCRIPTION
Add the following flags to the top pipelines and job generator:
- enableSourceRpm: to launch the source RPM build
- verifySigner: to launch a downstream build to verify if all packages
are signed
Add enable installers, signers and signers verification flags to
pipeline genrator. Remove hardcoded values for flags and infer their
values from defaults.json when not set as build argument.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>