### PR TITLE
Stop producing sig json files

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -926,7 +926,7 @@ class Build {
     */
     List<String> listArchives() {
         return context.sh(
-                script: '''find workspace/target/ | egrep '(.tar.gz|.zip|.msi|.pkg|.deb|.rpm|.tar.gz.sig)$' ''',
+                script: '''find workspace/target/ | egrep '(.tar.gz|.zip|.msi|.pkg|.deb|.rpm)$' ''',
                 returnStdout: true,
                 returnStatus: false
         )


### PR DESCRIPTION
listArchives is only used in 2 spots. First when we produce the
Windows jre installer. Second when we create the json metadata.
Therefore I believe it is best to remove the tar.gz.sig case
from this function

Issue ibmruntimes/Semeru-Runtimes#20

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>