### PR TITLE
Add FIPS testing

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -75,7 +75,12 @@ class Config11 {
                         "extended.system",
                         "special.functional",
                         "special.jck",
-                        "sanity.external"
+                        "sanity.external",
+                        "sanity.jck.fips",
+                        "extended.jck.fips",
+                        "special.jck.fips",
+                        "sanity.openjdk.fips",
+                        "extended.openjdk.fips"
                     ]
             ],
             configureArgs       : [


### PR DESCRIPTION
enable jck and openjdk FIPS testing for JDK11 xlinux weekly runs

Related: runtimes/backlog/issues/758
Depends on: https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/520
Depends on: https://github.com/adoptium/aqa-test-tools/pull/655

Signed-off-by: lanxia <lan_xia@ca.ibm.com>