### PR TITLE
Update configuration for JDK19

### DIFF
--- a/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk19_pipeline_config.groovy
@@ -6,12 +6,13 @@ class Config19 {
                 additionalNodeLabels: 'hw.arch.x86 && sw.os.osx.10_14',
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
+                bootJDK             : '18',
                 configureArgs       : [
                         temurin     : '--enable-dtrace',
                         openj9      : '--enable-dtrace --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                 ],
                 buildArgs           : [
-                        "openj9"    : '-create-jre-image'
+                        "openj9"    : '--create-jre-image'
                 ]
         ],
 
@@ -19,16 +20,23 @@ class Config19 {
                 os                  : 'linux',
                 arch                : 'x64',
                 additionalNodeLabels : [
-                        openj9      : 'hw.arch.x86 && sw.os.linux && (sw.os.cent.7 || sw.os.rhel.7)'
+                        openj9      : 'hw.arch.x86 && sw.os.linux'
                 ],
                 dockerImage: [
-                        temurin     : 'adoptopenjdk/centos6_build_image'
+                        temurin     : 'adoptopenjdk/centos6_build_image',
+                        openj9      : 'adoptopenjdk/centos7_build_image'
                 ],
+                dockerFile: [
+                        openj9      : 'pipelines/build/dockerFiles/cuda.dockerfile'
+                ],
+                dockerNode          : 'sw.tool.docker && sw.config.uid1000',
+                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
                 additionalTestLabels: [
                         openj9      : '!(sw.os.cent.6||sw.os.rhel.6)'
                 ],
+                bootJDK             : '18',
                 configureArgs       : [
                         openj9      : '--enable-dtrace --enable-jitserver --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
                         temurin     : '--enable-dtrace'
@@ -53,6 +61,7 @@ class Config19 {
                 additionalNodeLabels: 'hw.arch.x86 && sw.os.windows',
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
+                bootJDK             : '18',
                 configureArgs       : [
                         openj9      :'--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-jdk-rc-name="IBM Semeru Runtime"'
                 ],
@@ -80,7 +89,7 @@ class Config19 {
                 arch                : 'x86-32',
                 additionalNodeLabels: 'win2012&&vs2017',
                 buildArgs           : [
-                        temurin : '--jvm-variant client,server'
+                        temurin     : '--jvm-variant client,server'
                 ],
                 test                : 'default'
         ],
@@ -93,6 +102,7 @@ class Config19 {
                         openj9      : 'hw.arch.ppc64 && sw.os.aix.7_1'
                 ],
                 test                : 'default',
+                bootJDK             : '18',
                 configureArgs       : [
                         openj9      : '--disable-ccache --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                 ],
@@ -108,6 +118,7 @@ class Config19 {
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
                 additionalNodeLabels: 'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)',
+                bootJDK             : '18',
                 configureArgs       : [
                         temurin     : '--enable-dtrace',
                         openj9      : '--enable-dtrace --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
@@ -123,6 +134,7 @@ class Config19 {
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
                 additionalNodeLabels: 'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)',
+                bootJDK             : '18',
                 configureArgs       : [
                         temurin     : '--enable-dtrace',
                         openj9      : '--enable-dtrace --enable-jitserver --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
@@ -136,12 +148,13 @@ class Config19 {
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: [
-                        openj9      : 'hw.arch.aarch64 && sw.os.linux && sw.os.cent.7'
+                        openj9      : 'hw.arch.aarch64 && sw.os.linux'
                 ],
-                dockerImage         : [
-                        temurin     : 'adoptopenjdk/centos7_build_image'
-                ],
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerNode          : 'sw.tool.docker',
+                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : 'default',
+                bootJDK             : '18',
                 configureArgs       : [
                         temurin     : '--enable-dtrace',
                         openj9      : '--enable-dtrace --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
@@ -156,15 +169,16 @@ class Config19 {
                 arch                : 'aarch64',
                 additionalNodeLabels: [
                         temurin     : 'macos11',
-                        openj9      : 'ci.project.openj9 && hw.arch.aarch64 && sw.os.mac'
+                        openj9      : 'hw.arch.aarch64 && sw.os.mac'
                 ],
                 cleanWorkspaceAfterBuild: true,
+                bootJDK             : '18',
                 configureArgs       : [
                         openj9      : '--enable-dtrace --disable-warnings-as-errors --with-noncompressedrefs --disable-ddr --with-version-pre=ea --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                 ],
                 test                : [
-                        hotspot : 'default',
-                        openj9 : ['sanity.functional', 'extended.functional', 'sanity.openjdk', 'sanity.system']
+                        temurin     : 'default',
+                        openj9      : ['sanity.functional', 'extended.functional', 'sanity.openjdk', 'sanity.system']
                 ],
                 buildArgs           : [
                         "openj9"    : '--create-jre-image'


### PR DESCRIPTION
Use containers for Linux x86-64 and aarch64 for compilation with gcc7.5
or gcc-10.3.
Clean up ci.project.openj9 (added by default in addition to
ci.role.build.release, see formAdditionalBuildNodeLabels() method).
Set boot-jdk=18 (Temurin 18) as Semeru 19 does not compile with Temurin
19 (the default boot-jdk for JDK19).

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>