### PR TITLE
Enable FIPS testing in JDK17 weekly

### DIFF
--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -78,7 +78,31 @@ class Config17 {
                 ],
                 dockerNode          : 'sw.tool.docker && sw.config.uid1000',
                 dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
-                test                : 'default',
+                test                : [
+                        nightly: [
+                                "sanity.functional",
+                                "extended.functional",
+                                "sanity.openjdk",
+                                "sanity.perf",
+                                "sanity.jck",
+                                "sanity.system",
+                                "special.system"
+                        ],
+                        weekly : [
+                                "extended.openjdk",
+                                "extended.perf",
+                                "extended.jck",
+                                "extended.system",
+                                "special.functional",
+                                "special.jck",
+                                "sanity.external",
+                                "sanity.jck.fips",
+                                "extended.jck.fips",
+                                "special.jck.fips",
+                                "sanity.openjdk.fips",
+                                "extended.openjdk.fips"
+                        ]
+                ],
                 additionalTestLabels: [
                         openj9      : '!(centos6||rhel6)'
                 ],


### PR DESCRIPTION
Related: runtimes/backlog/issues/758
Depends on: https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/103

Signed-off-by: lanxia <lan_xia@ca.ibm.com>