### PR TITLE
Enable cmake for riscv build to remove freemarker dependency

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -371,7 +371,7 @@ class Config11 {
                     "bisheng"    : '--cross-compile --branch risc-v'
             ],
             configureArgs        : [
-                    "openj9"     : '--disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root',
+                    "openj9"     : '--disable-ddr --with-cmake --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root',
                     "bisheng"    : '--openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-jvm-features=shenandoahgc'
             ],
             test                 : false


### PR DESCRIPTION
Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>