### PR TITLE
enable sanity.functional.fips to run FIPS tests only

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -368,8 +368,12 @@ class Build {
                         def extraOptions = ""
                         if (isFipsTestBuild) {
                             jobParams.put('TEST_JOB_NAME', "${jobParams.TEST_JOB_NAME}_fips")
+                            if ("${jobParams.TEST_JOB_NAME}".contains("functional")) {
+                                jobParams.put('BUILD_LIST', "functional/cmdLineTests/fips")
+                            }
                             testFlag = "FIPS"
                             extraOptions = "-Dsemeru.fips=true"
+
                         }
                         def parallel = 'None'
                         def numMachinesPerTest = ''

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -76,6 +76,7 @@ class Config11 {
                         "special.functional",
                         "special.jck",
                         "sanity.external",
+                        "sanity.functional.fips",
                         "sanity.jck.fips",
                         "extended.jck.fips",
                         "special.jck.fips",

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -96,6 +96,7 @@ class Config17 {
                                 "special.functional",
                                 "special.jck",
                                 "sanity.external",
+                                "sanity.functional.fips",
                                 "sanity.jck.fips",
                                 "extended.jck.fips",
                                 "special.jck.fips",


### PR DESCRIPTION
resolves: runtimes/backlog/issues/826
depends on: https://github.com/eclipse-openj9/openj9/pull/15372
Signed-off-by: lanxia <lan_xia@ca.ibm.com>