### PR TITLE
Add CRIU support for JDK17 on Linux x86-64

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -93,16 +93,15 @@ class Config11 {
         x64LinuxCRIU  : [
             os                  : 'linux',
             arch                : 'x64',
-            additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.cent.7',
+            additionalNodeLabels : 'hw.arch.x86 && sw.os.linux && sw.os.cent.7 && ci.role.build.criu',
             test                : 'default',
             additionalTestLabels: [
-                        openj9      : 'ci.project.openj9 && hw.arch.x86 && sw.os.ubuntu && ci.role.test.criu'
+                        openj9      : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux && ci.role.test.criu'
             ],
             configureArgs       : [
                     "openj9"      : '--disable-ccache --enable-jitserver --enable-dtrace=auto --with-version-pre=ea --enable-criu-support --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
             ],
-            additionalFileNameTag: "criu",
-            buildArgs : "--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b criu-preview_1-release"
+            additionalFileNameTag: "criu"
         ],
 
         x64AlpineLinux  : [

--- a/pipelines/jobs/configurations/jdk17u.groovy
+++ b/pipelines/jobs/configurations/jdk17u.groovy
@@ -21,7 +21,7 @@ targetConfigurations = [
                 "openj9"
         ],
         "aarch64Mac": [
-            "openj9"
+                "openj9"
         ],
         "x64MacIBM": [
                 "openj9"
@@ -45,7 +45,10 @@ targetConfigurations = [
                 "openj9"
         ],
         "aarch64MacIBM": [
-            "openj9"
+                "openj9"
+        ],
+        "x64LinuxCRIU" : [ 
+                "openj9"
         ]
 
 ]

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -57,6 +57,24 @@ class Config17 {
                 ]
         ],
 
+        x64LinuxCRIU  : [
+            os                  : 'linux',
+            arch                : 'x64',
+            additionalNodeLabels : 'hw.arch.x86 && sw.os.linux && sw.os.cent.7 && ci.role.build.criu',
+            test                : 'default',
+            additionalTestLabels: [
+                        openj9  : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux && ci.role.test.criu'
+            ],
+            configureArgs       : [
+                    "openj9"    : '--disable-ccache --enable-criu-support --enable-dtrace --enable-jitserver --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-version-pre=ea'
+            ],
+            additionalFileNameTag: "criu",
+            buildArgs           : [
+                "openj9"    : '--create-jre-image'
+            ]
+        ],
+
+
         x64AlpineLinux  : [
                 os                  : 'alpine-linux',
                 arch                : 'x64',


### PR DESCRIPTION
Add x64LinuxCRIU platform to JDK17 pipelines.
Clean up configuration for JDK11 pipelines.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>