### PR TITLE
Enable all functional and sanity.external for CRIU nightly

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -95,7 +95,15 @@ class Config11 {
             os                  : 'linux',
             arch                : 'x64',
             additionalNodeLabels : 'hw.arch.x86 && sw.os.linux && sw.os.cent.7 && ci.role.build.criu',
-            test                : 'default',
+            test                : [
+                    nightly: [
+                        "sanity.functional",
+                        "extended.functional",
+                        "special.functional",
+                        "sanity.external"
+                    ],
+                    weekly : []
+            ],
             additionalTestLabels: [
                         openj9      : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux && ci.role.test.criu'
             ],

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -61,7 +61,15 @@ class Config17 {
             os                  : 'linux',
             arch                : 'x64',
             additionalNodeLabels : 'hw.arch.x86 && sw.os.linux && sw.os.cent.7 && ci.role.build.criu',
-            test                : 'default',
+            test                : [
+                    nightly: [
+                        "sanity.functional",
+                        "extended.functional",
+                        "special.functional",
+                        "sanity.external"
+                    ],
+                    weekly : []
+            ],
             additionalTestLabels: [
                         openj9  : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux && ci.role.test.criu'
             ],


### PR DESCRIPTION
Related: runtimes/backlog/issues/878

Signed-off-by: lanxia <lan_xia@ca.ibm.com>