### PR TITLE
Enabled dev.system on JDK11 xlinux

### DIFF
--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -58,8 +58,8 @@
         ],
         "enableTestDynamicParallel" : true,
         "defaultDynamicParas": {
-            "testLists"      : ["sanity.functional", "extended.functional", "sanity.system", "extended.system", "special.system", "sanity.jck", "extended.jck", "sanity.openjdk"],
-            "numMachines"    : ["3", "3", "3", "3", "5", "4", "8", "2"]
+            "testLists"      : ["sanity.functional", "extended.functional", "sanity.system", "extended.system", "special.system", "sanity.jck", "extended.jck", "sanity.openjdk", "dev.system"],
+            "numMachines"    : ["3", "3", "3", "3", "5", "4", "8", "2", "5"]
         }
     },
     "enableInstallers"       : true,

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -264,6 +264,7 @@ class Config11 {
                         "special.system"
                     ],
                     weekly : [
+                        "dev.system",
                         "extended.openjdk",
                         "extended.perf",
                         "extended.jck",


### PR DESCRIPTION
- Enabled dev.system on JDK11 xlinux weekly run
- parallel on 5 machines

Related: backlog/issues/926

Signed-off-by: Lan Xia <Lan_Xia@ca.ibm.com>