### PR TITLE
Comment out authorizationMatrix

### DIFF
--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -54,6 +54,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
     }
     properties {
         // Hide all non Temurin builds from public view
+        /*
         if (VARIANT != "temurin") {
             authorizationMatrix {
                 inheritanceStrategy {
@@ -70,6 +71,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                 'hudson.model.Run.Update:AdoptOpenJDK*build', 'hudson.model.Run.Update:AdoptOpenJDK*build-triage'])
             }
         }
+        */
         disableConcurrentBuilds()
         copyArtifactPermission {
             projectNames('*')

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -64,6 +64,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
 
     properties {
         // Hide top level pipeline access from the public as they contain non Temurin artefacts
+        /*
         authorizationMatrix {
             inheritanceStrategy {
                 // Do not inherit permissions from global configuration
@@ -80,6 +81,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
             'hudson.model.Item.Workspace:AdoptOpenJDK*build', 'hudson.model.Item.Workspace:AdoptOpenJDK*build-triage',
             'hudson.model.Run.Update:AdoptOpenJDK*build', 'hudson.model.Run.Update:AdoptOpenJDK*build-triage'])
         }
+        */
         pipelineTriggers {
             triggers {
                 cron {


### PR DESCRIPTION
Only used for Adopt farm to block non-temurin builds from public view

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>