### PR TITLE
Only force authorizationMatrix on Adoptium's jenkins

### DIFF
--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -54,8 +54,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
     }
     properties {
         // Hide all non Temurin builds from public view
-        /*
-        if (VARIANT != "temurin") {
+        if (JENKINS_URL.contains("adopt") && VARIANT != 'temurin') {
             authorizationMatrix {
                 inheritanceStrategy {
                     // Do not inherit permissions from global configuration
@@ -71,7 +70,6 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                 'hudson.model.Run.Update:AdoptOpenJDK*build', 'hudson.model.Run.Update:AdoptOpenJDK*build-triage'])
             }
         }
-        */
         disableConcurrentBuilds()
         copyArtifactPermission {
             projectNames('*')

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -64,24 +64,24 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
 
     properties {
         // Hide top level pipeline access from the public as they contain non Temurin artefacts
-        /*
-        authorizationMatrix {
-            inheritanceStrategy {
-                // Do not inherit permissions from global configuration
-                nonInheriting()
-            } 
-            permissions(['hudson.model.Item.Build:AdoptOpenJDK*build', 'hudson.model.Item.Build:AdoptOpenJDK*build-triage', 
-            'hudson.model.Item.Cancel:AdoptOpenJDK*build', 'hudson.model.Item.Cancel:AdoptOpenJDK*build-triage',
-            'hudson.model.Item.Configure:AdoptOpenJDK*build', 'hudson.model.Item.Configure:AdoptOpenJDK*build-triage',
-            'hudson.model.Item.Read:AdoptOpenJDK*build', 'hudson.model.Item.Read:AdoptOpenJDK*build-triage',
-            // eclipse-temurin-bot needs read access for TRSS
-            'hudson.model.Item.Read:eclipse-temurin-bot',
-            // eclipse-temurin-compliance bot needs read access for https://ci.eclipse.org/temurin-compliance 
-            'hudson.model.Item.Read:eclipse-temurin-compliance-bot',
-            'hudson.model.Item.Workspace:AdoptOpenJDK*build', 'hudson.model.Item.Workspace:AdoptOpenJDK*build-triage',
-            'hudson.model.Run.Update:AdoptOpenJDK*build', 'hudson.model.Run.Update:AdoptOpenJDK*build-triage'])
+        if (JENKINS_URL.contains("adopt")) {
+            authorizationMatrix {
+                inheritanceStrategy {
+                    // Do not inherit permissions from global configuration
+                    nonInheriting()
+                }
+                permissions(['hudson.model.Item.Build:AdoptOpenJDK*build', 'hudson.model.Item.Build:AdoptOpenJDK*build-triage',
+                'hudson.model.Item.Cancel:AdoptOpenJDK*build', 'hudson.model.Item.Cancel:AdoptOpenJDK*build-triage',
+                'hudson.model.Item.Configure:AdoptOpenJDK*build', 'hudson.model.Item.Configure:AdoptOpenJDK*build-triage',
+                'hudson.model.Item.Read:AdoptOpenJDK*build', 'hudson.model.Item.Read:AdoptOpenJDK*build-triage',
+                // eclipse-temurin-bot needs read access for TRSS
+                'hudson.model.Item.Read:eclipse-temurin-bot',
+                // eclipse-temurin-compliance bot needs read access for https://ci.eclipse.org/temurin-compliance
+                'hudson.model.Item.Read:eclipse-temurin-compliance-bot',
+                'hudson.model.Item.Workspace:AdoptOpenJDK*build', 'hudson.model.Item.Workspace:AdoptOpenJDK*build-triage',
+                'hudson.model.Run.Update:AdoptOpenJDK*build', 'hudson.model.Run.Update:AdoptOpenJDK*build-triage'])
+            }
         }
-        */
         pipelineTriggers {
             triggers {
                 cron {


### PR DESCRIPTION
The changes introduced by #154 #155 are specific
to Adoptium and can cause unwanted behaviour on
other users' Jenkins'. Simple solution to only
run that part of the code on Jenkins' that are
owned by Adopt (have adopt in the URL).

Probably good enough to resolve #156 while we're here.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>