### PR TITLE
CUSTOMIZED_SDK_URL should only be used when SDK_RESOURCE=customized

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -444,6 +444,7 @@ class Build {
                                     parameters: [
                                             //context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
                                             //context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
+                                            context.string(name: 'SDK_RESOURCE', value: "customized"),
                                             context.string(name: 'CUSTOMIZED_SDK_URL', value: artifactsUrls),
                                             context.string(name: 'CUSTOMIZED_SDK_URL_CREDENTIAL_ID', value: artifactoryCredential),
                                             context.string(name: 'RELEASE_TAG', value: "${buildConfig.SCM_REF}"),


### PR DESCRIPTION
Fixes [issue #2097](https://github.com/adoptium/aqa-tests/issues/2097)