### PR TITLE
Add CUSTOMIZED_SDK_URL and CUSTOMIZED_SDK_URL_CREDENTIAL_ID for smoke…

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -309,8 +309,8 @@ class Build {
                             propagate: false,
                             parameters: [
                                     context.string(name: 'SDK_RESOURCE', value: 'customized'),
-                                    context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
-                                    context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
+                                    context.string(name: 'CUSTOMIZED_SDK_URL', value: artifactsUrls),
+                                    context.string(name: 'CUSTOMIZED_SDK_URL_CREDENTIAL_ID', value: artifactoryCredential),
                                     context.string(name: 'JDK_VERSION', value: "${jobParams.JDK_VERSIONS}"),
                                     context.string(name: 'LABEL_ADDITION', value: additionalTestLabel),
                                     context.booleanParam(name: 'KEEP_REPORTDIR', value: buildConfig.KEEP_TEST_REPORTDIR),


### PR DESCRIPTION
… test builds

https://github.com/ibmruntimes/ci-jenkins-pipelines/pull/108 set SDK_RESOURCE to `customized`. However, without CUSTOMIZED_SDK_URL and CUSTOMIZED_SDK_URL_CREDENTIAL_ID values, SmokeTests will not able to download SDK. 

Fix: runtimes/backlog/issues/982

Signed-off-by: Lan Xia <Lan_Xia@ca.ibm.com>