### PR TITLE
Enable dev.jck + add geo labels for aix

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -387,6 +387,7 @@ class Build {
                         }
 
                         def additionalTestLabel = buildConfig.ADDITIONAL_TEST_LABEL
+                        def relatedNodeLabel = ''
                         if (testType  == 'dev.openjdk') {
                             context.println "${testType} need extra label sw.tool.docker"
                             if (additionalTestLabel == '') {
@@ -399,6 +400,14 @@ class Build {
                                 additionalTestLabel += '&&'
                             }
                             additionalTestLabel += 'sw.tool.podman&&(sw.os.ubuntu.22||sw.os.rhel.8)'
+                        } else if (testType  == 'dev.jck') {
+                            if (buildConfig.TARGET_OS == "aix") {
+	                            if (additionalTestLabel != '') {
+	                                additionalTestLabel += '&&'
+	                            }  
+	                            additionalTestLabel += 'ci.geo.raleigh&&sw.tool.jckshare'
+	                            relatedNodeLabel = 'ci.geo.raleigh&&sw.tool.jckrefserver'
+	                        }
                         }
 
                         def jobParams = getAQATestJobParams(testType)
@@ -485,7 +494,8 @@ class Build {
                                             context.string(name: 'DOCKER_REGISTRY_URL_CREDENTIAL_ID', value: DOCKER_REGISTRY_URL_CREDENTIAL_ID),
                                             context.string(name: 'VENDOR_TEST_REPOS', value: VENDOR_TEST_REPOS),
                                             context.string(name: 'VENDOR_TEST_BRANCHES', value: VENDOR_TEST_BRANCHES),
-                                            context.string(name: 'VENDOR_TEST_DIRS', value: VENDOR_TEST_DIRS)],
+                                            context.string(name: 'VENDOR_TEST_DIRS', value: VENDOR_TEST_DIRS),
+                                            context.string(name: 'RELATED_NODES', value: relatedNodeLabel)],
                                             wait: true
                             context.node('worker') {
                                 def result = testJob.getResult()

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -298,7 +298,28 @@ class Config11 {
             additionalNodeLabels: [
                     openj9:  'hw.arch.ppc64 && sw.os.aix.7_2'
             ],
-            test                : 'default',
+            test                : [
+                    nightly: [
+                        'sanity.functional',
+                        'extended.functional',
+                        'sanity.openjdk',
+                        'sanity.perf',
+                        'sanity.jck',
+                        'sanity.system',
+                        'special.system'
+                    ],
+                    weekly : [
+                        'extended.openjdk',
+                        'extended.perf',
+                        'extended.jck',
+                        'extended.system',
+                        'special.functional',
+                        'special.jck',
+                        'dev.openjdk',
+                        'dev.system',
+                        'dev.jck'
+                    ]
+            ],
             additionalFileNameTag: 'IBM',
             cleanWorkspaceAfterBuild: true,
             buildArgs : '--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk'


### PR DESCRIPTION
- Enable dev.jck weekly 
- Add geo labels for aix for multijvm tck tests using two nodes.

Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>