### PR TITLE
Enable dev.external in JDK17

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -395,11 +395,10 @@ class Build {
                                 additionalTestLabel += '&&sw.tool.docker'
                             }
                         } else if (testType  == 'dev.external') {
-                            if (additionalTestLabel == '') {
-                                additionalTestLabel = 'sw.tool.podman'
-                            } else {
-                                additionalTestLabel += '&&sw.tool.podman'
+                            if (additionalTestLabel != '') {
+                                additionalTestLabel += '&&'
                             }
+                            additionalTestLabel += 'sw.tool.podman&&(sw.os.ubuntu.22||sw.os.rhel.8)'
                         }
 
                         def jobParams = getAQATestJobParams(testType)

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -240,6 +240,7 @@ class Config17 {
                                 'special.system'
                         ],
                         weekly : [
+                                'dev.external',
                                 'extended.openjdk',
                                 'extended.perf',
                                 'extended.jck',


### PR DESCRIPTION
- Enable dev.external in JDK17 xlinux
- Restrict dev.external on ub22 or rhel8 (i.e., cannot use ub20 for testing)