### PR TITLE
Enable dev.jck for IBM JDK11 on xLinux, aLinux, xMac, aMac, x64 Windows

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -392,6 +392,7 @@ class Build {
 
                         def additionalTestLabel = buildConfig.ADDITIONAL_TEST_LABEL
                         def relatedNodeLabel = ''
+                        def additionalArtifactsRequired = ''
                         if (testType  == 'dev.openjdk') {
                             context.println "${testType} need extra label sw.tool.docker"
                             if (additionalTestLabel == '') {
@@ -412,6 +413,7 @@ class Build {
 	                            additionalTestLabel += 'ci.geo.raleigh&&sw.tool.jckshare'
 	                            relatedNodeLabel = 'ci.geo.raleigh&&sw.tool.jckrefserver'
 	                        }
+	                        additionalArtifactsRequired = 'RI_JDK'
                         }
 
                         def jobParams = getAQATestJobParams(testType)
@@ -499,7 +501,8 @@ class Build {
                                             context.string(name: 'VENDOR_TEST_REPOS', value: VENDOR_TEST_REPOS),
                                             context.string(name: 'VENDOR_TEST_BRANCHES', value: VENDOR_TEST_BRANCHES),
                                             context.string(name: 'VENDOR_TEST_DIRS', value: VENDOR_TEST_DIRS),
-                                            context.string(name: 'RELATED_NODES', value: relatedNodeLabel)],
+                                            context.string(name: 'RELATED_NODES', value: relatedNodeLabel), 
+                                            context.string(name: 'ADDITIONAL_ARTIFACTS_REQUIRED', value: additionalArtifactsRequired)],
                                             wait: true
                             context.node('worker') {
                                 def result = testJob.getResult()

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -235,7 +235,26 @@ class Config11 {
             os                  : 'mac',
             arch                : 'x64',
             additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.osx.10_15',
-            test                : 'default',
+            test                : [
+                    nightly: [
+                        'sanity.functional',
+                        'extended.functional',
+                        'sanity.openjdk',
+                        'sanity.perf',
+                        'sanity.jck',
+                        'sanity.system',
+                        'special.system'
+                    ],
+                    weekly : [
+                        'extended.openjdk',
+                        'extended.perf',
+                        'extended.jck',
+                        'extended.system',
+                        'special.functional',
+                        'special.jck',
+                        'dev.jck'
+                    ]
+            ],
             configureArgs       : [
                     'openj9'      : '--enable-dtrace=auto '
             ],
@@ -282,7 +301,8 @@ class Config11 {
                         'extended.openjdk.fips',
                         'sanity.system.fips',
                         'extended.system.fips',
-                        'special.system.fips'
+                        'special.system.fips',
+                        'dev.jck'
                     ]
             ],
             configureArgs       : [
@@ -301,7 +321,26 @@ class Config11 {
             buildArgs : [
                     openj9 : '--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk'
             ],
-            test                : 'default',
+            test                : [
+                    nightly: [
+                        'sanity.functional',
+                        'extended.functional',
+                        'sanity.openjdk',
+                        'sanity.perf',
+                        'sanity.jck',
+                        'sanity.system',
+                        'special.system'
+                    ],
+                    weekly : [
+                        'extended.openjdk',
+                        'extended.perf',
+                        'extended.jck',
+                        'extended.system',
+                        'special.functional',
+                        'special.jck',
+                        'dev.jck'
+                    ]
+            ],
             configureArgs       : [
                     'openj9'      : '--with-jdk-rc-name="IBM Semeru Runtime"'
             ],
@@ -331,8 +370,6 @@ class Config11 {
                         'extended.system',
                         'special.functional',
                         'special.jck',
-                        'dev.openjdk',
-                        'dev.system',
                         'dev.jck'
                     ]
             ],
@@ -431,7 +468,8 @@ class Config11 {
                         'extended.system',
                         'special.functional',
                         'special.jck',
-                        'sanity.external'
+                        'sanity.external',
+                        'dev.jck'
                     ]
             ],
             configureArgs       : [
@@ -456,7 +494,24 @@ class Config11 {
                         openj9      : '--enable-dtrace --disable-warnings-as-errors --with-noncompressedrefs'
                 ],
                 test                : [
-                        openj9 : 'default'
+                    nightly: [
+                        'sanity.functional',
+                        'extended.functional',
+                        'sanity.openjdk',
+                        'sanity.perf',
+                        'sanity.jck',
+                        'sanity.system',
+                        'special.system'
+                    ],
+                    weekly : [
+                        'extended.openjdk',
+                        'extended.perf',
+                        'extended.jck',
+                        'extended.system',
+                        'special.functional',
+                        'special.jck',
+                        'dev.jck'
+                    ]
                 ],
                 additionalFileNameTag: 'IBM',
                 buildArgs : '--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk'


### PR DESCRIPTION
- Enable dev.jck on IBM xLinux, aLinux, xMac, aMac, x64 Windows
- set ADDITIONAL_ARTIFACTS_REQUIRED=RI_JDK for dev.jck builds 

Related to backlog/issues/1028

Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>