### PR TITLE
Disable separate criu specs for z p linux

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -15,9 +15,7 @@ targetConfigurations = [
         'ppc64leLinuxIBM'  : [ 'openj9' ],
         's390xLinuxIBM'    : [ 'openj9' ],
         'aarch64LinuxIBM'  : [ 'openj9' ],
-        'aarch64MacIBM'    : [ 'openj9' ],
-        'ppc64leLinuxCRIU' : [ 'openj9' ],
-        's390xLinuxCRIU'   : [ 'openj9' ]
+        'aarch64MacIBM'    : [ 'openj9' ]
 ]
 
 // Weeknights at 9:00pm

--- a/pipelines/jobs/configurations/jdk17u.groovy
+++ b/pipelines/jobs/configurations/jdk17u.groovy
@@ -46,12 +46,6 @@ targetConfigurations = [
         ],
         'aarch64MacIBM': [
                 'openj9'
-        ],
-        'ppc64leLinuxCRIU' : [
-                'openj9'
-        ],
-        's390xLinuxCRIU' : [
-                'openj9'
         ]
 
 ]


### PR DESCRIPTION
Enabled by default on z.
Enabled via build config option on p