### PR TITLE
Update build schedule for JDK19 and JDK20

### DIFF
--- a/pipelines/jobs/configurations/jdk19u.groovy
+++ b/pipelines/jobs/configurations/jdk19u.groovy
@@ -35,4 +35,6 @@ weekly_release_scmReferences=[
     'openj9'         : ''
 ]
 
+disableJob = true
+
 return this

--- a/pipelines/jobs/configurations/jdk20u.groovy
+++ b/pipelines/jobs/configurations/jdk20u.groovy
@@ -26,7 +26,7 @@ targetConfigurations = [
 ]
 
 // Weekly 7:30 pm Wed
-triggerSchedule_nightly = '30 19 * * 3'
+triggerSchedule_nightly = '30 19 * * 1-4'
 // 11:00 am Sat
 triggerSchedule_weekly = '0 11 * * 6'
 


### PR DESCRIPTION
Disable JDK19 builds.
Schedule JDK20 builds nightly.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>