### PR TITLE
remove additionalTestLabel

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -426,11 +426,6 @@ class Build {
                             } else {
                                 additionalTestLabel += '&&sw.tool.docker'
                             }
-                        } else if (testType  == 'dev.external') {
-                            if (additionalTestLabel != '') {
-                                additionalTestLabel += '&&'
-                            }
-                            additionalTestLabel += 'sw.tool.podman&&sw.tool.container.criu&&(sw.os.ubuntu.22||sw.os.rhel.8)'
                         } else if (testType  == 'dev.jck') {
                             if (buildConfig.TARGET_OS == "aix") {
 	                            if (additionalTestLabel != '') {


### PR DESCRIPTION
Due to https://github.com/adoptium/aqa-tests/issues/4465, the test pipeline (i.e., dev.external) will handle the image upload and image pull. We no longer need to set additional label in the build pipeline.