### PR TITLE
Enable sanity.functional and dev.external on machines with criu318

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -444,6 +444,16 @@ class Build {
 	                        additionalArtifactsRequired = 'RI_JDK'
                         }
 
+                        String additionalFileNameTag = buildConfig.ADDITIONAL_FILE_NAME_TAG
+                        if (additionalFileNameTag == "criu" && buildConfig.ARCHITECTURE == 'ppc64le') {
+                            if (testType  == 'dev.external' || testType  == 'sanity.functional') {
+                                if (additionalTestLabel != '') {
+	                                additionalTestLabel += '&&'
+	                            }
+                                additionalTestLabel += 'ci.role.test.criu318'
+                            }
+                        }
+
                         def jobParams = getAQATestJobParams(testType)
 
                         def testFlag = ''

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -547,7 +547,8 @@ class Config11 {
                     nightly: [
                         'sanity.functional',
                         'extended.functional',
-                        'special.functional'
+                        'special.functional',
+                        'dev.external'
                     ],
                     weekly : []
             ],

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -497,7 +497,8 @@ class Config17 {
                     nightly: [
                         'sanity.functional',
                         'extended.functional',
-                        'special.functional'
+                        'special.functional',
+                        'dev.external'
                     ],
                     weekly : []
                 ],


### PR DESCRIPTION
related: runtimes/backlog/issues/1099