### PR TITLE
Reverts CUDA9 end of support temp workaround 

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2224,11 +2224,6 @@ class Build {
                                     throw new Exception("[ERROR] Controller docker file scm checkout timeout (${buildTimeouts.DOCKER_CHECKOUT_TIMEOUT} HOURS) has been reached. Exiting...")
                                 }
 
-                                // TEMP Workaround infra issue 8157
-                                // Cuda 9.0 containers no longer supported.
-                                // Copy local Cuda-9.0 dir into the Docker build context
-                                context.sh(script: "mkdir -p cuda-9.0/nvvm && cp -r /usr/local/cuda-9.0/include cuda-9.0/ && cp -r /usr/local/cuda-9.0/nvvm/include cuda-9.0/nvvm/", returnStdout:true)
-
                                 context.docker.build("build-image", "--build-arg image=${buildConfig.DOCKER_IMAGE} -f ${buildConfig.DOCKER_FILE} .").inside(buildConfig.DOCKER_ARGS) {
                                     buildScripts(
                                         cleanWorkspace,


### PR DESCRIPTION
Regarding the CUDA 9.0 end of support, this was a temporary workaround. Now we can use DUDA 12 and we do not need it anymore.

Resolves issue runtimes/infrastructure#8331