### PR TITLE
Remove unneeded criu configs

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -174,9 +174,6 @@ class Build {
             default: variant = 'hs'
         }
         def jobName = "Test_openjdk${jobParams['JDK_VERSIONS']}_${variant}_${testType}_${jobParams['ARCH_OS_LIST']}"
-        if (buildConfig.ADDITIONAL_FILE_NAME_TAG == 'criu') {
-            jobName += "_criu"
-        }
 
         jobParams.put('TEST_JOB_NAME', jobName)
         return jobParams
@@ -1555,7 +1552,7 @@ class Build {
         }
 
         if (variant == "openj9") {
-             fileName = "ibm-semeru-" + ((additionalFileNameTag == "IBM") ? "certified" : "open") + ((additionalFileNameTag == "criu") ? "-ea" : "") + "-jdk_${architecture}_${os}"
+             fileName = "ibm-semeru-" + ((additionalFileNameTag == "IBM") ? "certified" : "open") + "-jdk_${architecture}_${os}"
         }
 
         if (overrideFileNameVersion) {

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -142,7 +142,7 @@ class Config11 {
             ],
             configureArgs       : [
                     'temurin'     : '--enable-dtrace=auto',
-                    'openj9'      : '--enable-dtrace=auto --enable-criu-support --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
+                    'openj9'      : '--enable-dtrace=auto --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
             ],
             buildArgs           : [
                     'temurin'   : '--create-sbom'
@@ -171,7 +171,7 @@ class Config11 {
             test                : 'default',
             configureArgs       : [
                     'temurin' : '--enable-dtrace=auto',
-                    'openj9' : '--enable-dtrace=auto  --enable-criu-support --without-version-opt  --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
+                    'openj9' : '--enable-dtrace=auto  --without-version-opt  --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
                     'corretto' : '--enable-dtrace=auto',
                     'dragonwell' : '--enable-dtrace=auto --with-extra-cflags=\"-march=armv8.2-a+crypto\" --with-extra-cxxflags=\"-march=armv8.2-a+crypto\"',
                     'bisheng' : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server'
@@ -437,7 +437,7 @@ class Config11 {
                     openj9:  'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)'
             ],
             configureArgs       : [
-                        'openj9'      : '--enable-dtrace=auto --enable-criu-support'
+                        'openj9'      : '--enable-dtrace=auto'
             ],
             additionalFileNameTag: 'IBM',
             buildArgs : '--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk'
@@ -476,7 +476,7 @@ class Config11 {
             ],
             configureArgs       : [
                     'temurin' : '--enable-dtrace=auto',
-                    'openj9' : '--enable-dtrace=auto  --enable-criu-support --without-version-opt',
+                    'openj9' : '--enable-dtrace=auto  --without-version-opt',
                     'corretto' : '--enable-dtrace=auto',
                     'dragonwell' : '--enable-dtrace=auto --with-extra-cflags=\"-march=armv8.2-a+crypto\" --with-extra-cxxflags=\"-march=armv8.2-a+crypto\"',
                     'bisheng' : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server'
@@ -517,67 +517,6 @@ class Config11 {
                 ],
                 additionalFileNameTag: 'IBM',
                 buildArgs : '--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk'
-        ],
-
-        x64LinuxCRIU  : [
-            os                  : 'linux',
-            arch                : 'x64',
-            additionalNodeLabels : 'hw.arch.x86 && sw.os.linux && (sw.os.cent.7||sw.os.rhel.7) && ci.role.build.criu',
-            test                : [
-                    nightly: [
-                        'sanity.functional',
-                        'extended.functional',
-                        'special.functional',
-                        'sanity.external'
-                    ],
-                    weekly : []
-            ],
-            additionalTestLabels: [
-                        openj9      : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux && ci.role.test.criu'
-            ],
-            configureArgs       : [
-                    'openj9'      : '--disable-ccache --enable-dtrace=auto --with-version-pre=ea --enable-criu-support --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
-            ],
-            additionalFileNameTag: 'criu'
-        ],
-
-        ppc64leLinuxCRIU    : [
-            os                  : 'linux',
-            arch                : 'ppc64le',
-            test                : [
-                    nightly: [
-                        'sanity.functional',
-                        'extended.functional',
-                        'special.functional'
-                    ],
-                    weekly : []
-            ],
-            additionalNodeLabels: [
-                    openj9:  'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)'
-            ],
-            configureArgs       : [
-                    'temurin'     : '--enable-dtrace=auto',
-                    'openj9'      : '--enable-dtrace=auto --with-version-pre=ea --enable-criu-support --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
-            ],
-            additionalFileNameTag: 'criu'
-        ],
-
-        s390xLinuxCRIU    : [
-            os                  : 'linux',
-            arch                : 's390x',
-            test                : [
-                    nightly: [
-                        'sanity.functional',
-                        'extended.functional',
-                        'special.functional'
-                    ],
-                    weekly : []
-            ],
-            additionalNodeLabels: [
-                    openj9:  'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)'
-            ],
-            configureArgs       : '--enable-dtrace=auto  --with-version-pre=ea --enable-criu-support --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
-            additionalFileNameTag: 'criu'
         ]
   ]
 

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -169,7 +169,7 @@ class Config17 {
                         'temurin'   : '--create-jre-image'
                 ],
                 configureArgs       : [
-                        'openj9'      : '--enable-criu-support --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
+                        'openj9'      : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                 ]
         ],
 
@@ -190,7 +190,7 @@ class Config17 {
                         'openj9'    : '--create-jre-image',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ],
-                configureArgs       : '--enable-dtrace  --enable-criu-support --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
+                configureArgs       : '--enable-dtrace  --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
         ],
 
         aarch64Mac: [
@@ -402,7 +402,7 @@ class Config17 {
                         openj9:  'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)'
                 ],
                 configureArgs       : [
-                        'openj9'      : '--enable-criu-support'
+                        'openj9'      : ''
                 ],
                 additionalFileNameTag: 'IBM',
                 buildArgs : '--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk17 -b ibm_sdk --create-jre-image'
@@ -439,7 +439,7 @@ class Config17 {
                         openj9:  'hw.arch.aarch64 && sw.os.linux'
                 ],
                 configureArgs       : [
-                        openj9      : '--enable-dtrace  --enable-criu-support'
+                        openj9      : '--enable-dtrace  '
                 ],
                 additionalFileNameTag: 'IBM',
                 buildArgs : [
@@ -465,78 +465,6 @@ class Config17 {
                 buildArgs : [
                         'openj9'    : '--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk17 -b ibm_sdk --create-jre-image'
                 ]
-        ],
-
-        x64LinuxCRIU  : [
-            os                  : 'linux',
-            arch                : 'x64',
-            additionalNodeLabels : 'hw.arch.x86 && sw.os.linux && (sw.os.cent.7||sw.os.rhel.7) && ci.role.build.criu',
-            test                : [
-                    nightly: [
-                        'sanity.functional',
-                        'extended.functional',
-                        'special.functional',
-                        'sanity.external'
-                    ],
-                    weekly : []
-            ],
-            additionalTestLabels: [
-                        openj9  : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux && ci.role.test.criu'
-            ],
-            configureArgs       : [
-                    'openj9'    : '--disable-ccache --enable-criu-support --enable-dtrace --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-version-pre=ea'
-            ],
-            additionalFileNameTag: 'criu',
-            buildArgs           : [
-                'openj9'    : '--create-jre-image'
-            ]
-        ],
-
-        ppc64leLinuxCRIU    : [
-                os                  : 'linux',
-                arch                : 'ppc64le',
-                test                : [
-                    nightly: [
-                        'sanity.functional',
-                        'extended.functional',
-                        'special.functional'
-                    ],
-                    weekly : []
-                ],
-                cleanWorkspaceAfterBuild: true,
-                additionalNodeLabels: [
-                        openj9:  'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)'
-                ],
-                additionalFileNameTag: 'criu',
-                buildArgs           : [
-                        'openj9'    : '--create-jre-image'
-                ],
-                configureArgs       : [
-                        'openj9'      : '--enable-criu-support --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
-                ]
-        ],
-
-        s390xLinuxCRIU    : [
-                os                  : 'linux',
-                arch                : 's390x',
-                test                : 'default',
-                cleanWorkspaceAfterBuild: true,
-                additionalNodeLabels: [
-                        openj9:  'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)'
-                ],
-                test                : [
-                    nightly: [
-                        'sanity.functional',
-                        'extended.functional',
-                        'special.functional'
-                    ],
-                    weekly : []
-                ],
-                additionalFileNameTag: 'criu',
-                buildArgs           : [
-                        'openj9'      : '--create-jre-image'
-                ],
-                configureArgs       : '--enable-dtrace --enable-criu-support --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
         ]
   ]
 


### PR DESCRIPTION
Now that CRIU is enabled by default on platforms for all versions that support it we can remove configs. Resolves issue#8372