### PR TITLE
Wrap build process in withRegistry for Docker builds

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2265,14 +2265,17 @@ class Build {
                                     throw new Exception("[ERROR] Controller docker file scm checkout timeout (${buildTimeouts.DOCKER_CHECKOUT_TIMEOUT} HOURS) has been reached. Exiting...")
                                 }
 
-                                context.docker.build("build-image", "--build-arg image=${buildConfig.DOCKER_IMAGE} -f ${buildConfig.DOCKER_FILE} .").inside(buildConfig.DOCKER_ARGS) {
-                                    buildScripts(
-                                        cleanWorkspace,
-                                        cleanWorkspaceAfter,
-                                        cleanWorkspaceBuildOutputAfter,
-                                        filename,
-                                        useAdoptShellScripts
-                                    )
+                                if (buildConfig.DOCKER_CREDENTIAL) {
+                                    context.docker.withRegistry(buildConfig.DOCKER_REGISTRY, buildConfig.DOCKER_CREDENTIAL) {
+                                        context.docker.build("build-image", "--build-arg image=${buildConfig.DOCKER_IMAGE} -f ${buildConfig.DOCKER_FILE} .").inside(buildConfig.DOCKER_ARGS) {
+                                            buildScripts(
+                                                cleanWorkspace,
+                                                cleanWorkspaceAfter,
+                                                cleanWorkspaceBuildOutputAfter,
+                                                filename,
+                                                useAdoptShellScripts
+                                            )
+                                        }
                                 }
                             } else {
                                 dockerImageDigest = dockerImageDigest.replaceAll("\\[", "").replaceAll("\\]", "")


### PR DESCRIPTION
If we're building in a docker container we pull the cuda container during the build process. If we're not logged into a registry we can hit a rate limit.