### PR TITLE
Add BASE_DOCKER_REGISTRY_CREDENTIAL_ID for external-test

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -414,10 +414,14 @@ class Build {
 
                         def DOCKER_REGISTRY_URL = ''
                         def DOCKER_REGISTRY_URL_CREDENTIAL_ID = ''
+                        def BASE_DOCKER_REGISTRY_CREDENTIAL_ID = ''
                         if ("${testType}".contains('external')) {
                             DOCKER_REGISTRY_URL = 'docker-na.artifactory.swg-devops.com/sys-rt-docker-local'
                             DOCKER_REGISTRY_URL_CREDENTIAL_ID = artifactoryCredential
                             rerunIterations = '0'
+                            if (buildConfig.DOCKER_CREDENTIAL) {
+                                BASE_DOCKER_REGISTRY_CREDENTIAL_ID = buildConfig.DOCKER_CREDENTIAL
+                            }
                         }
 
                         def additionalTestLabel = buildConfig.ADDITIONAL_TEST_LABEL
@@ -523,6 +527,7 @@ class Build {
                                             context.booleanParam(name: 'DYNAMIC_COMPILE', value: DYNAMIC_COMPILE),
                                             context.string(name: 'DOCKER_REGISTRY_URL', value: DOCKER_REGISTRY_URL),
                                             context.string(name: 'DOCKER_REGISTRY_URL_CREDENTIAL_ID', value: DOCKER_REGISTRY_URL_CREDENTIAL_ID),
+                                            context.string(name: 'BASE_DOCKER_REGISTRY_URL_CREDENTIAL_ID', value: BASE_DOCKER_REGISTRY_URL_CREDENTIAL_ID),
                                             context.string(name: 'VENDOR_TEST_REPOS', value: VENDOR_TEST_REPOS),
                                             context.string(name: 'VENDOR_TEST_BRANCHES', value: VENDOR_TEST_BRANCHES),
                                             context.string(name: 'VENDOR_TEST_DIRS', value: VENDOR_TEST_DIRS),

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -117,6 +117,7 @@ class Config11 {
             additionalNodeLabels: [
                     openj9:  'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)'
             ],
+            dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
             configureArgs       : '--enable-dtrace=auto --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
             buildArgs           : [
                     'temurin'   : '--create-sbom'
@@ -140,6 +141,7 @@ class Config11 {
             additionalNodeLabels: [
                     openj9:  'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)'
             ],
+            dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
             configureArgs       : [
                     'temurin'     : '--enable-dtrace=auto',
                     'openj9'      : '--enable-dtrace=auto --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
@@ -404,6 +406,7 @@ class Config11 {
             additionalNodeLabels: [
                     openj9:  'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)'
             ],
+            dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
             configureArgs       : '--enable-dtrace=auto',
             additionalFileNameTag: 'IBM',
             buildArgs : '--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk'
@@ -436,6 +439,7 @@ class Config11 {
             additionalNodeLabels: [
                     openj9:  'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)'
             ],
+            dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
             configureArgs       : [
                         'openj9'      : '--enable-dtrace=auto'
             ],

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -143,6 +143,7 @@ class Config17 {
                 additionalNodeLabels: [
                         openj9:  'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)'
                 ],
+                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 reproducibleCompare : [
                         'temurin'   : true
                 ],
@@ -161,6 +162,7 @@ class Config17 {
                 additionalNodeLabels: [
                         openj9:  'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)'
                 ],
+                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 reproducibleCompare : [
                         'temurin'   : true
                 ],
@@ -369,6 +371,7 @@ class Config17 {
                 additionalNodeLabels: [
                         openj9:  'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)'
                 ],
+                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 configureArgs       : '--enable-dtrace',
                 additionalFileNameTag: 'IBM',
                 buildArgs : '--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk17 -b ibm_sdk --create-jre-image'
@@ -401,6 +404,7 @@ class Config17 {
                 additionalNodeLabels: [
                         openj9:  'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)'
                 ],
+                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 configureArgs       : [
                         'openj9'      : ''
                 ],

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -127,6 +127,7 @@ class Config21 {
                 additionalNodeLabels: [
                         openj9      : 'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)'
                 ],
+                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 configureArgs       : [
                         openj9      : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                 ],
@@ -147,6 +148,7 @@ class Config21 {
                 additionalNodeLabels: [
                         openj9      : 'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)'
                 ],
+                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 reproducibleCompare : [
                         'temurin'   : true
                 ],
@@ -319,6 +321,7 @@ class Config21 {
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
                 additionalNodeLabels: 'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)',
+                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 additionalFileNameTag: 'IBM',
                 buildArgs           : '--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk21 -b ibm_sdk --create-jre-image'
         ],
@@ -329,6 +332,7 @@ class Config21 {
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
                 additionalNodeLabels: 'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)',
+                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 additionalFileNameTag: 'IBM',
                 buildArgs           : '--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk21 -b ibm_sdk --create-jre-image'
         ],


### PR DESCRIPTION
- BASE_DOCKER_REGISTRY_CREDENTIAL_ID is needed to increase daily image pull limit when running container-based external testing
- Related Issue: runtimes/backlog/issues/1234