### PR TITLE
Add dockerCredential for jdk8 plinux and zlinux

### DIFF
--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -143,6 +143,7 @@ class Config8 {
                 additionalNodeLabels: [
                         openj9:  'hw.arch.s390x && (sw.os.cent.7 || sw.os.rhel.7)'
                 ],
+                dockerCredential : '9f50c848-8764-440d-b95a-1d295c21713e',
                 configureArgs      : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
                 test               : [
                         nightly: [
@@ -214,6 +215,7 @@ class Config8 {
                 additionalNodeLabels: [
                         openj9:  'hw.arch.ppc64le && (sw.os.cent.7 || sw.os.rhel.7)'
                 ],
+                dockerCredential : '9f50c848-8764-440d-b95a-1d295c21713e',
                 configureArgs       : [
                         'openj9'      : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                 ],


### PR DESCRIPTION
- Since sanity.external for jdk 8 enabled on these platforms, need to add dockerCredential for them too
- The dockerhub login will solve the pull limit reached issue
- Similar PR for jdk 11 & 17: https://github.com/ibmruntimes/ci-jenkins-pipelines/pull/185/files
- Related Issue: github_ibm/runtimes/backlog/issues/1262