### PR TITLE
Bundle OpenJCEPlus and get GSKit binaries from Artifactory

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1962,8 +1962,16 @@ class Build {
                                 repoHandler.checkoutUserBuild(context)
                                 printGitRepoInfo()
                                 if (buildConfig.VARIANT == "openj9") {
-                                    context.sshagent(['83181e25-eea4-4f55-8b3e-e79615733226']) {
-                                        context.sh(script: "./${DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
+                                    def buildArgs = ''
+                                    if (DEFAULTS_JSON['bundle-openjceplus'] == true) {
+                                        buildArgs = ' --bundle-openjceplus'
+                                    }
+                                    context.withEnv(['BUILD_ARGS=' + buildArgs]) {
+                                        context.sshagent(['83181e25-eea4-4f55-8b3e-e79615733226']) {
+                                            context.withCredentials([usernamePassword(credentialsId: '7c1c2c28-650f-49e0-afd1-ca6b60479546', passwordVariable: 'GSKIT_PASSWORD', usernameVariable: 'GSKIT_USERNAME')]) {
+                                                context.sh(script: "./${DEFAULTS_JSON['scriptDirectories']['buildfarm']}")
+                                            }
+                                        }
                                     }
                                 } else {
                                     context.sh(script: "./${DEFAULTS_JSON['scriptDirectories']['buildfarm']}")

--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -92,6 +92,7 @@
     "enableSourceRpm"        : true,
     "enableSigner"           : true,
     "verifySigner"           : false,
+    "bundle-openjceplus"     : true,
     "importLibraryScript"    : "pipelines/build/common/import_lib.groovy",
     "defaultsUrl"            : "https://raw.githubusercontent.com/ibmruntimes/ci-jenkins-pipelines/ibm/pipelines/defaults.json"
 }


### PR DESCRIPTION
A new flag is added to the `DEFAULTS_JSON` struct to allow for bundling `OpenJCEPlus` with Semeru. Said flag is then potentially propagated to the subsequent scripts. 

The appropriate credentials are, also, used to allow for the required downloading of the `GSKit` binaries.

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)