### PR TITLE
Enable dev.external on aarch64LinuxIBM in JDK21

### DIFF
--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -402,7 +402,27 @@ class Config21 {
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 dockerNode          : 'sw.tool.docker',
                 dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
-                test                : 'default',
+                test                : [
+                        nightly: [
+                                'sanity.functional',
+                                'extended.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'special.system'
+                        ],
+                        weekly : [
+                                'dev.external',
+                                'extended.openjdk',
+                                'extended.perf',
+                                'extended.jck',
+                                'extended.system',
+                                'special.functional',
+                                'special.jck',
+                                'sanity.external'
+                        ]
+                ],
                 configureArgs       : '--enable-dtrace',
                 additionalFileNameTag: 'IBM',
                 cleanWorkspaceAfterBuild: true,


### PR DESCRIPTION
related: backlog/issues/1133