### PR TITLE
Add support for FIPS140-3

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -423,11 +423,12 @@ class Build {
                 testStages["${testType}"] = {
                     context.println "Running test: ${testType}"
                     context.stage("${testType}") {
-                        def isFipsTestBuild = false
                         def rerunIterations = '3'
-                        if ("${testType}".contains(".fips140_2")) {
-                            testType = testType.replace(".fips140_2","")
-                            isFipsTestBuild = true
+                        def fipsTestBuildSuffix = "";
+                        if ("${testType}".contains(".fips")) {
+                            String[] tokens = testType.split('.')
+                            testType = tokens[0] + "." + tokens[1]
+                            fipsTestBuildSuffix = tokens[2]
                             rerunIterations = '0'
                         }
                         def keep_test_reportdir = buildConfig.KEEP_TEST_REPORTDIR
@@ -519,9 +520,9 @@ class Build {
                         def jobParams = getAQATestJobParams(testType)
 
                         def testFlag = ''
-                        if (isFipsTestBuild) {
-                            jobParams.put('TEST_JOB_NAME', "${jobParams.TEST_JOB_NAME}_fips140_2")
-                            testFlag = 'FIPS140_2'
+                        if (fipsTestBuildSuffix?.trim()) {
+                            jobParams.put('TEST_JOB_NAME', "${jobParams.TEST_JOB_NAME}_${fipsTestBuildSuffix}")
+                            testFlag = fipsTestBuildSuffix.replace("fips", "FIPS")
                         }
                         def parallel = 'None'
                         def numMachinesPerTest = ''

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -318,7 +318,9 @@ class Config11 {
                         'extended.jck.fips140_2',
                         'special.jck.fips140_2',
                         'sanity.openjdk.fips140_2',
-                        'extended.openjdk.fips140_2'                        
+                        'extended.openjdk.fips140_2',
+                        'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                        'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                     ],
                     release : [
                         'sanity.functional',
@@ -342,7 +344,9 @@ class Config11 {
                         'extended.jck.fips140_2',
                         'special.jck.fips140_2',
                         'sanity.openjdk.fips140_2',
-                        'extended.openjdk.fips140_2'
+                        'extended.openjdk.fips140_2',
+                        'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                        'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                     ]
             ],
             configureArgs       : [
@@ -374,7 +378,54 @@ class Config11 {
             additionalNodeLabels: [
                     openj9:  'hw.arch.ppc64 && sw.os.aix.7_2'
             ],
-            test                : 'default',
+            test                : [
+                    nightly: [
+                        'sanity.functional',
+                        'sanity.openjdk',
+                        'sanity.perf',
+                        'sanity.jck',
+                        'sanity.system',
+                        'extended.functional',
+                        'extended.openjdk',
+                        'special.system'
+                    ],
+                    weekly : [
+                        'sanity.functional',
+                        'sanity.openjdk',
+                        'sanity.perf',
+                        'sanity.jck',
+                        'sanity.system',
+                        'extended.functional',
+                        'extended.openjdk',
+                        'extended.perf',
+                        'extended.jck',
+                        'extended.system',
+                        'special.functional',
+                        'special.jck',
+                        'special.openjdk',
+                        'special.system',
+                        'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                        'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
+                    ],
+                    release : [
+                        'sanity.functional',
+                        'sanity.openjdk',
+                        'sanity.perf',
+                        'sanity.jck',
+                        'sanity.system',
+                        'extended.functional',
+                        'extended.openjdk',
+                        'extended.perf',
+                        'extended.jck',
+                        'extended.system',
+                        'special.functional',
+                        'special.jck',
+                        'special.openjdk',
+                        'special.system',
+                        'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                        'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
+                    ]
+            ],
             additionalFileNameTag: 'IBM',
             cleanWorkspaceAfterBuild: true,
             buildArgs : '--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk'
@@ -419,7 +470,9 @@ class Config11 {
                         'extended.jck.fips140_2',
                         'special.jck.fips140_2',
                         'sanity.openjdk.fips140_2',
-                        'extended.openjdk.fips140_2'                        
+                        'extended.openjdk.fips140_2',
+                        'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                        'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                     ],
                     release : [
                         'sanity.functional',
@@ -443,7 +496,9 @@ class Config11 {
                         'extended.jck.fips140_2',
                         'special.jck.fips140_2',
                         'sanity.openjdk.fips140_2',
-                        'extended.openjdk.fips140_2'
+                        'extended.openjdk.fips140_2',
+                        'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                        'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                     ]
             ],
             additionalNodeLabels: [
@@ -494,7 +549,9 @@ class Config11 {
                         'extended.jck.fips140_2',
                         'special.jck.fips140_2',
                         'sanity.openjdk.fips140_2',
-                        'extended.openjdk.fips140_2'                        
+                        'extended.openjdk.fips140_2',
+                        'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                        'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                     ],
                     release : [
                         'sanity.functional',
@@ -518,7 +575,9 @@ class Config11 {
                         'extended.jck.fips140_2',
                         'special.jck.fips140_2',
                         'sanity.openjdk.fips140_2',
-                        'extended.openjdk.fips140_2'
+                        'extended.openjdk.fips140_2',
+                        'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                        'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                     ]
             ],
             additionalNodeLabels: [

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -315,7 +315,9 @@ class Config17 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'                        
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ],
                         release : [
                                 'sanity.functional',
@@ -339,7 +341,9 @@ class Config17 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ]
                 ],
                 additionalTestLabels: [
@@ -374,7 +378,54 @@ class Config17 {
                 additionalNodeLabels: [
                         openj9:  'hw.arch.ppc64 && sw.os.aix.7_2'
                 ],
-                test                : 'default',
+                test                : [
+                        nightly: [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'special.system'
+                        ],
+                        weekly : [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'extended.perf',
+                                'extended.jck',
+                                'extended.system',
+                                'special.functional',
+                                'special.jck',
+                                'special.openjdk',
+                                'special.system',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
+                        ],
+                        release : [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'extended.perf',
+                                'extended.jck',
+                                'extended.system',
+                                'special.functional',
+                                'special.jck',
+                                'special.openjdk',
+                                'special.system',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
+                        ]
+                ],
                 configureArgs       : [
                         'openj9'      : '--disable-ccache'
                 ],
@@ -421,7 +472,9 @@ class Config17 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'                        
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ],
                         release : [
                                 'sanity.functional',
@@ -445,7 +498,9 @@ class Config17 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ]
                 ],
                 additionalNodeLabels: [
@@ -496,7 +551,9 @@ class Config17 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'                        
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ],
                         release : [
                                 'sanity.functional',
@@ -520,7 +577,9 @@ class Config17 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ]
                 ],
                 additionalNodeLabels: [

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -285,7 +285,9 @@ class Config21 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'                        
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ],
                         release : [
                                 'sanity.functional',
@@ -309,7 +311,9 @@ class Config21 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ]
                 ],
                 cleanWorkspaceAfterBuild: true,
@@ -335,7 +339,54 @@ class Config21 {
                 os                  : 'aix',
                 arch                : 'ppc64',
                 additionalNodeLabels: 'hw.arch.ppc64 && sw.os.aix.7_2',
-                test                : 'default',
+                test                : [
+                        nightly: [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'special.system'
+                        ],
+                        weekly : [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'extended.perf',
+                                'extended.jck',
+                                'extended.system',
+                                'special.functional',
+                                'special.jck',
+                                'special.openjdk',
+                                'special.system',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
+                        ],
+                        release : [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'extended.perf',
+                                'extended.jck',
+                                'extended.system',
+                                'special.functional',
+                                'special.jck',
+                                'special.openjdk',
+                                'special.system',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
+                        ]
+                ],
                 cleanWorkspaceAfterBuild: true,
                 configureArgs       : '--disable-ccache',
                 additionalFileNameTag: 'IBM',
@@ -381,7 +432,9 @@ class Config21 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'                        
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ],
                         release : [
                                 'sanity.functional',
@@ -405,7 +458,9 @@ class Config21 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ]
                 ],
                 cleanWorkspaceAfterBuild: true,
@@ -454,7 +509,9 @@ class Config21 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'                        
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ],
                         release : [
                                 'sanity.functional',
@@ -478,7 +535,9 @@ class Config21 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ]
                 ],
                 cleanWorkspaceAfterBuild: true,

--- a/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
@@ -69,7 +69,9 @@ class Config22 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'                        
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ],
                         release : [
                                 'sanity.functional',
@@ -92,7 +94,9 @@ class Config22 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ]
                 ],
                 cleanWorkspaceAfterBuild: true,
@@ -165,7 +169,54 @@ class Config22 {
                         temurin: 'xlc16&&aix720',
                         openj9:  'hw.arch.ppc64 && sw.os.aix.7_2'
                 ],
-                test                : 'default',
+                test                : [
+                        nightly: [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'special.system'
+                        ],
+                        weekly : [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'extended.perf',
+                                'extended.jck',
+                                'extended.system',
+                                'special.functional',
+                                'special.jck',
+                                'special.openjdk',
+                                'special.system',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
+                        ],
+                        release : [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'extended.perf',
+                                'extended.jck',
+                                'extended.system',
+                                'special.functional',
+                                'special.jck',
+                                'special.openjdk',
+                                'special.system',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
+                        ]
+                ],
                 additionalTestLabels: [
                         temurin      : 'sw.os.aix.7_2'
                 ],
@@ -217,7 +268,9 @@ class Config22 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'                        
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ],
                         release : [
                                 'sanity.functional',
@@ -240,7 +293,9 @@ class Config22 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ]
                 ],
                 cleanWorkspaceAfterBuild: true,
@@ -298,7 +353,9 @@ class Config22 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'                        
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ],
                         release : [
                                 'sanity.functional',
@@ -321,7 +378,9 @@ class Config22 {
                                 'extended.jck.fips140_2',
                                 'special.jck.fips140_2',
                                 'sanity.openjdk.fips140_2',
-                                'extended.openjdk.fips140_2'
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
                         ]
                 ],
                 cleanWorkspaceAfterBuild: true,


### PR DESCRIPTION
Enable 140-3_OpenJCEPlusFIPS sanity.openjdk and extended.openjdk on xlinux, plinux, zlinux and AIX on JDK11/17/21/22.

related: backlog/issues/1450