### PR TITLE
Add nightly targets to weekly build jdk8

### DIFF
--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -38,6 +38,13 @@ class Config8 {
                                 'special.system'
                         ],
                         weekly : [
+                                'sanity.functional',
+                                'extended.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'special.system',
                                 'extended.openjdk',
                                 'extended.perf',
                                 'extended.jck',
@@ -179,6 +186,13 @@ class Config8 {
                                 'special.system'
                         ],
                         weekly : [
+                                'sanity.functional',
+                                'extended.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'special.system',
                                 'extended.openjdk',
                                 'extended.perf',
                                 'extended.jck',
@@ -255,6 +269,13 @@ class Config8 {
                                 'special.system'
                         ],
                         weekly : [
+                                'sanity.functional',
+                                'extended.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'special.system',
                                 'extended.openjdk',
                                 'extended.perf',
                                 'extended.jck',


### PR DESCRIPTION
Each list needs to be explicitly defined now.
This was missed.