### PR TITLE
Change to exclude list of versions bundling OpenJCEPlus

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1972,7 +1972,8 @@ class Build {
                                 printGitRepoInfo()
                                 if (buildConfig.VARIANT == "openj9") {
                                     def openjceplusBuildArgs = ''
-                                    if (DEFAULTS_JSON['bundle-openjceplus'] == true) {
+                                    def javaVersion = getJavaVersionNumber()
+                                    if (!DEFAULTS_JSON['exclude-openjceplus'].contains(javaVersion)) {
                                         if (env.BUILD_ARGS != null && !env.BUILD_ARGS.isEmpty()) {
                                             openjceplusBuildArgs = env.BUILD_ARGS + ' --bundle-openjceplus'
                                         } else {

--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -97,7 +97,7 @@
     "enableSourceRpm"        : true,
     "enableSigner"           : true,
     "verifySigner"           : false,
-    "bundle-openjceplus"     : true,
+    "exclude-openjceplus"    : [8, 11, 22, 23],
     "importLibraryScript"    : "pipelines/build/common/import_lib.groovy",
     "defaultsUrl"            : "https://raw.githubusercontent.com/ibmruntimes/ci-jenkins-pipelines/ibm/pipelines/defaults.json"
 }


### PR DESCRIPTION
A list of Java versions to be excluded from bundling `OpenJCEPlus` with is introduced, in place of the existing boolean value.

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)