### PR TITLE
issue-9015 prevents build failure if sign failed, in non-release runs

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2495,7 +2495,10 @@ class Build {
                         // Sign job timeout managed by Jenkins job config
                         sign(versionInfo)
                     } catch (FlowInterruptedException e) {
-                        throw new Exception("[ERROR] Sign job timeout (${buildTimeouts.SIGN_JOB_TIMEOUT} HOURS) has been reached OR the downstream sign job failed. Exiting...")
+                        if (buildConfig.RELEASE){
+                            throw new Exception("[ERROR] Sign job timeout (${buildTimeouts.SIGN_JOB_TIMEOUT} HOURS) has been reached OR the downstream sign job failed. Exiting...")
+                        }
+                        context.println("[WARNING] Sign job timeout (${buildTimeouts.SIGN_JOB_TIMEOUT} HOURS) has been reached OR the downstream sign job failed. Skipping sign...")
                     }
                 }
 


### PR DESCRIPTION
now sign can only fails build when buildConfig.RELEASE. Otherwise it will only show a warning. https://github.ibm.com/runtimes/infrastructure/issues/9015