### PR TITLE
Use ssh clones for all Semeru builds

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -11,7 +11,8 @@ class Config11 {
                     'temurin'     : '--enable-dtrace=auto'
             ],
             buildArgs           : [
-                    'temurin'   : '--create-sbom'
+                    'temurin'   : '--create-sbom',
+                    'openj9'    : '--ssh'
             ]
         ],
 
@@ -36,7 +37,8 @@ class Config11 {
                     'bisheng'     : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server --disable-warnings-as-errors'
             ],
             buildArgs            : [
-                'temurin'     : '--create-source-archive --create-sbom'
+                'temurin'     : '--create-source-archive --create-sbom',
+                'openj9'      : '--ssh'
             ]
         ],
 
@@ -72,7 +74,8 @@ class Config11 {
             ],
             test                : 'default',
             buildArgs : [
-                temurin : '--jvm-variant client,server --create-sbom'
+                temurin : '--jvm-variant client,server --create-sbom',
+                'openj9'    : '--ssh'
             ],
             configureArgs       : [
                     'openj9'      : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-jdk-rc-name="IBM Semeru Runtime"',
@@ -106,7 +109,8 @@ class Config11 {
                     'openj9'      : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
             ],
             buildArgs           : [
-                    'temurin'   : '--create-sbom'
+                    'temurin'   : '--create-sbom',
+                    'openj9'    : '--ssh'
             ]
         ],
 
@@ -120,7 +124,8 @@ class Config11 {
             dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
             configureArgs       : '--enable-dtrace=auto --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
             buildArgs           : [
-                    'temurin'   : '--create-sbom'
+                    'temurin'   : '--create-sbom',
+                    'openj9'    : '--ssh'
             ]
         ],
 
@@ -147,7 +152,8 @@ class Config11 {
                     'openj9'      : '--enable-dtrace=auto --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
             ],
             buildArgs           : [
-                    'temurin'   : '--create-sbom'
+                    'temurin'   : '--create-sbom',
+                    'openj9'    : '--ssh'
             ]
         ],
 
@@ -177,6 +183,9 @@ class Config11 {
                     'corretto' : '--enable-dtrace=auto',
                     'dragonwell' : '--enable-dtrace=auto --with-extra-cflags=\"-march=armv8.2-a+crypto\" --with-extra-cxxflags=\"-march=armv8.2-a+crypto\"',
                     'bisheng' : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server'
+            ],
+            buildArgs           : [
+                    'openj9'    : '--ssh'
             ]
         ],
 
@@ -200,7 +209,7 @@ class Config11 {
             ],
             buildArgs            : [
                     'hotspot'    : '--create-sbom',
-                    'openj9'     : '--cross-compile',
+                    'openj9'     : '--cross-compile --ssh',
                     'bisheng'    : '--cross-compile --branch risc-v'
             ],
             configureArgs        : [
@@ -235,7 +244,8 @@ class Config11 {
                         openj9 : 'default'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom',
+                        'openj9'    : '--ssh'
                 ]
         ],
 

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -14,7 +14,7 @@ class Config17 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'openj9'      : '--create-jre-image',
+                        'openj9'      : '--create-jre-image --ssh',
                         'temurin'     : '--create-jre-image --create-sbom'
                 ],
                 configureArgs       : '--enable-dtrace --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
@@ -46,7 +46,7 @@ class Config17 {
                         'temurin'     : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-source-archive --create-jre-image --create-sbom'
                 ]
         ],
@@ -85,7 +85,7 @@ class Config17 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ],
                 configureArgs: '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-jdk-rc-name="IBM Semeru Runtime"',
@@ -126,7 +126,7 @@ class Config17 {
                         temurin: 'sw.os.aix.7_2'
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ],
                 configureArgs : [
@@ -148,7 +148,7 @@ class Config17 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'openj9'      : '--create-jre-image',
+                        'openj9'      : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ],
                 configureArgs       : '--enable-dtrace --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
@@ -167,7 +167,7 @@ class Config17 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image'
                 ],
                 configureArgs       : [
@@ -189,7 +189,7 @@ class Config17 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ],
                 configureArgs       : '--enable-dtrace  --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
@@ -214,7 +214,7 @@ class Config17 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -20,7 +20,7 @@ class Config21 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],
@@ -50,7 +50,7 @@ class Config21 {
                         'temurin'   : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-source-archive --create-jre-image --create-sbom --enable-sbom-strace'
                 ]
         ],
@@ -93,7 +93,7 @@ class Config21 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],
@@ -114,7 +114,7 @@ class Config21 {
                         openj9      : '--disable-ccache --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],
@@ -135,7 +135,7 @@ class Config21 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],
@@ -156,7 +156,7 @@ class Config21 {
                         'openj9'    : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
         ],
@@ -180,7 +180,7 @@ class Config21 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom --enable-sbom-strace'
                 ]
         ],
@@ -201,7 +201,7 @@ class Config21 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],

--- a/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22_pipeline_config.groovy
@@ -20,7 +20,7 @@ class Config22 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],
@@ -110,7 +110,7 @@ class Config22 {
                         'temurin'   : '--enable-dtrace'
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-source-archive --create-jre-image --create-sbom'
                 ]
         ],
@@ -153,7 +153,7 @@ class Config22 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],
@@ -174,7 +174,7 @@ class Config22 {
                         openj9      : '--disable-ccache --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],
@@ -255,7 +255,7 @@ class Config22 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],
@@ -336,7 +336,7 @@ class Config22 {
                         'openj9'    : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],
@@ -406,7 +406,7 @@ class Config22 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],
@@ -427,7 +427,7 @@ class Config22 {
                         'temurin'   : true
                 ],
                 buildArgs           : [
-                        'openj9'    : '--create-jre-image',
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -12,7 +12,8 @@ class Config8 {
                 configureArgs      : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
                 test                 : 'default',
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom',
+                        'openj9'    : '--ssh'
                 ]
         ],
 
@@ -93,7 +94,8 @@ class Config8 {
                         'dragonwell'  : '--enable-unlimited-crypto --with-jvm-variants=server --with-zlib=system',
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-source-archive --create-sbom'
+                        'temurin'   : '--create-source-archive --create-sbom',
+                        'openj9'    : '--ssh'
                 ]
         ],
 
@@ -131,7 +133,8 @@ class Config8 {
                 configureArgs      : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
                 test                 : 'default',
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom',
+                        'openj9'    : '--ssh'
                 ]
         ],
 
@@ -144,7 +147,8 @@ class Config8 {
                         openj9  : 'ci.project.openj9 && hw.arch.x86 && sw.os.windows'
                 ],
                 buildArgs : [
-                        temurin : '--jvm-variant client,server --create-sbom'
+                        temurin : '--jvm-variant client,server --create-sbom',
+                        'openj9'    : '--ssh'
                 ],
                 configureArgs      : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
                 test                 : 'default'
@@ -166,7 +170,8 @@ class Config8 {
                 ],
                 cleanWorkspaceAfterBuild: true,
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom',
+                        'openj9'    : '--ssh'
                 ]
         ],
 
@@ -241,7 +246,8 @@ class Config8 {
                         ]
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom',
+                        'openj9'    : '--ssh'
                 ]
         ],
 
@@ -336,7 +342,8 @@ class Config8 {
                         'openj9'      : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom',
+                        'openj9'    : '--ssh'
                 ]
         ],
 
@@ -414,7 +421,8 @@ class Config8 {
                         ]
                 ],
                 buildArgs           : [
-                        'temurin'   : '--create-sbom'
+                        'temurin'   : '--create-sbom',
+                        'openj9'    : '--ssh'
                 ]
         ],
   ]


### PR DESCRIPTION
Many machines are having issues with curl. Ie. git clone over https. CE already uses ssh since we clone from GHE.