### PR TITLE
enables sanity.perf in x64 linux for EBC

### DIFF
--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -93,7 +93,7 @@
             "numMachines"    : ["3", "3", "3", "3", "5", "4", "8", "2", "3", "5"]
         },
         "ebcEnabledTargets":{
-            "linux_x64" :       [""],
+            "linux_x64" :       ["sanity.perf"],
             "aix_ppc64" :       [""],
             "linux_aarch64" :   [""],
             "linux_ppc64le" :   [""],


### PR DESCRIPTION
After the issue with registering EBC nodes resolved now we can enable back the sanity.perf in semeru build pipelines.