### PR TITLE
issue_9128 removes condition which only let rhel7 to be pulled

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2432,8 +2432,8 @@ class Build {
                                     throw new Exception("[ERROR] Controller clean workspace timeout (${buildTimeouts.CONTROLLER_CLEAN_TIMEOUT} HOURS) has been reached. Exiting...")
                                 }
                             }
-                            if (!("${buildConfig.DOCKER_IMAGE}".contains('rhel'))) {
-                                // Pull the docker image from DockerHub
+                            if (buildConfig.DOCKER_IMAGE) {
+                                // Pull the docker image from buildConfig.DOCKER_REGISTRY
                                 try {
                                     context.timeout(time: buildTimeouts.DOCKER_PULL_TIMEOUT, unit: 'HOURS') {
                                         if (buildConfig.DOCKER_CREDENTIAL) {


### PR DESCRIPTION
It let all all docker images to be pulled not only rhel7

Signed-off-by: mahdi@ib.com