### PR TITLE
issue_9128 solves issue working with non-default docker registries

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2457,7 +2457,9 @@ class Build {
                                 }
                             }
                             // Store the pulled docker image digest as 'buildinfo'
-                            dockerImageDigest = context.sh(script: "docker inspect --format='{{.RepoDigests}}' ${buildConfig.DOCKER_IMAGE}", returnStdout:true)
+                            def long_docker_image_name = context.sh(script: "docker image ls | grep ${buildConfig.DOCKER_IMAGE} | head -n1 | awk '{print \$1}'", returnStdout:true).trim()
+                            context.sh(script: "docker tag '${long_docker_image_name}' '${buildConfig.DOCKER_IMAGE}'", returnStdout:false)
+                            dockerImageDigest = context.sh(script: "docker inspect --format='{{index .RepoDigests 0}}' ${long_docker_image_name}", returnStdout:true)
 
                             // Use our dockerfile if DOCKER_FILE is defined
                             if (buildConfig.DOCKER_FILE) {
@@ -2495,7 +2497,6 @@ class Build {
                                     }
                                 }
                             } else {
-                                dockerImageDigest = dockerImageDigest.replaceAll("\\[", "").replaceAll("\\]", "")
                                 String dockerRunArg="-e \"BUILDIMAGESHA=$dockerImageDigest\""
 
                                 // Are we running podman in Docker CLI Emulation mode?


### PR DESCRIPTION
while working with non-default docker registry, the local image tag will be DOCKER_REGISTRY+DOCKER_IMAGE. This change will add a tag with DOCKER_IMAGE only then the rest of pipeline witch works with DOCKER_IMAGE will not fail. Also it improves fetching .RepoDigests so do not need `dockerImageDigest = dockerImageDigest.replaceAll("\\[", "").replaceAll("\\]", "")` anymore

Signed-off-by: mahdi@ibm.com