### PR TITLE
issue_9128 resolves the issue with login to wrong docker registery

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -121,7 +121,8 @@ class Config11 {
             additionalNodeLabels: [
                     openj9:  'ci.project.openj9 && hw.arch.s390x'
             ],
-            dockerImage: 'https://docker-na.artifactory.swg-devops.com/sys-rt-docker-local/semeru/s390_rhel7_build_image',
+            dockerImage: 'sys-rt-docker-local/semeru/s390_rhel7_build_image',
+            dockerRegistry: 'https://docker-na.artifactory.swg-devops.com/',
             dockerCredential : '7c1c2c28-650f-49e0-afd1-ca6b60479546',
             dockerNode : 'sw.tool.docker',
             configureArgs       : '--enable-dtrace=auto --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
@@ -542,7 +543,8 @@ class Config11 {
             additionalNodeLabels: [
                     openj9:  'ci.project.openj9 && hw.arch.s390x'
             ],
-            dockerImage: 'https://docker-na.artifactory.swg-devops.com/sys-rt-docker-local/semeru/s390_rhel7_build_image',
+            dockerImage: 'sys-rt-docker-local/semeru/s390_rhel7_build_image',
+            dockerRegistry: 'https://docker-na.artifactory.swg-devops.com/',
             dockerCredential : '7c1c2c28-650f-49e0-afd1-ca6b60479546',
             dockerNode : 'sw.tool.docker',
             configureArgs       : '--enable-dtrace=auto',

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -143,7 +143,8 @@ class Config17 {
                 additionalNodeLabels: [
                         openj9:  'ci.project.openj9 && hw.arch.s390x'
                 ],
-                dockerImage: 'https://docker-na.artifactory.swg-devops.com/sys-rt-docker-local/semeru/s390_rhel7_build_image',
+                dockerImage: 'sys-rt-docker-local/semeru/s390_rhel7_build_image',
+                dockerRegistry: 'https://docker-na.artifactory.swg-devops.com/',
                 dockerCredential : '7c1c2c28-650f-49e0-afd1-ca6b60479546',
                 dockerNode : 'sw.tool.docker',
                 reproducibleCompare : [
@@ -513,7 +514,8 @@ class Config17 {
                 additionalNodeLabels: [
                         openj9:  'ci.project.openj9 && hw.arch.s390x'
                 ],
-                dockerImage: 'https://docker-na.artifactory.swg-devops.com/sys-rt-docker-local/semeru/s390_rhel7_build_image',
+                dockerImage: 'sys-rt-docker-local/semeru/s390_rhel7_build_image',
+                dockerRegistry: 'https://docker-na.artifactory.swg-devops.com/',
                 dockerCredential : '7c1c2c28-650f-49e0-afd1-ca6b60479546',
                 dockerNode : 'sw.tool.docker',
                 configureArgs       : '--enable-dtrace',

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -128,7 +128,8 @@ class Config21 {
                 additionalNodeLabels: [
                         openj9:  'ci.project.openj9 && hw.arch.s390x'
                 ],
-                dockerImage: 'https://docker-na.artifactory.swg-devops.com/sys-rt-docker-local/semeru/s390_rhel7_build_image',
+                dockerImage: 'sys-rt-docker-local/semeru/s390_rhel7_build_image',
+                dockerRegistry: 'https://docker-na.artifactory.swg-devops.com/',
                 dockerCredential : '7c1c2c28-650f-49e0-afd1-ca6b60479546',
                 dockerNode : 'sw.tool.docker',
                 configureArgs       : [
@@ -475,7 +476,8 @@ class Config21 {
                 additionalNodeLabels: [
                         openj9:  'ci.project.openj9 && hw.arch.s390x'
                 ],
-                dockerImage: 'https://docker-na.artifactory.swg-devops.com/sys-rt-docker-local/semeru/s390_rhel7_build_image',
+                dockerImage: 'sys-rt-docker-local/semeru/s390_rhel7_build_image',
+                dockerRegistry: 'https://docker-na.artifactory.swg-devops.com/',
                 dockerCredential : '7c1c2c28-650f-49e0-afd1-ca6b60479546',
                 dockerNode : 'sw.tool.docker',
                 additionalFileNameTag: 'IBM',

--- a/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
@@ -242,7 +242,8 @@ class Config22 {
                 additionalNodeLabels: [
                         openj9:  'ci.project.openj9 && hw.arch.s390x'
                 ],
-                dockerImage: 'https://docker-na.artifactory.swg-devops.com/sys-rt-docker-local/semeru/s390_rhel7_build_image',
+                dockerImage: 'sys-rt-docker-local/semeru/s390_rhel7_build_image',
+                dockerRegistry: 'https://docker-na.artifactory.swg-devops.com/',
                 dockerCredential : '7c1c2c28-650f-49e0-afd1-ca6b60479546',
                 dockerNode : 'sw.tool.docker',
                 configureArgs       : [

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -182,7 +182,8 @@ class Config8 {
                 additionalNodeLabels: [
                         openj9:  'ci.project.openj9 && hw.arch.s390x'
                 ],
-                dockerImage: 'https://docker-na.artifactory.swg-devops.com/sys-rt-docker-local/semeru/s390_rhel7_build_image',
+                dockerImage: 'sys-rt-docker-local/semeru/s390_rhel7_build_image',
+                dockerRegistry: 'https://docker-na.artifactory.swg-devops.com/',
                 dockerCredential : '7c1c2c28-650f-49e0-afd1-ca6b60479546',
                 dockerNode : 'sw.tool.docker',
                 configureArgs      : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',


### PR DESCRIPTION
It separates docker registery from docker image and prevents from login to default registery on z-builds which image stored in local artifactory.

Signed-off-by: mahdi@ibm.com