### PR TITLE
Enable jdk23 semeru builds

### DIFF
--- a/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk22u_pipeline_config.groovy
@@ -141,7 +141,7 @@ class Config22 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
-                 additionalNodeLabels: [
+                additionalNodeLabels: [
                         openj9      : 'hw.arch.x86 && sw.os.windows',
                         temurin     : 'win2022&&vs2022'
                 ],

--- a/pipelines/jobs/configurations/jdk23.groovy
+++ b/pipelines/jobs/configurations/jdk23.groovy
@@ -1,42 +1,34 @@
 targetConfigurations = [
         'x64Mac'      : [
-                'temurin'
+                'openj9'
         ],
         'x64Linux'    : [
-                'temurin'
-        ],
-        'x64AlpineLinux' : [
-                'temurin'
-        ],
-        'aarch64AlpineLinux' : [
-                'temurin'
+                'openj9'
         ],
         'x64Windows'  : [
-                'temurin'
+                'openj9'
         ],
         'ppc64Aix'    : [
-                'temurin'
+                'openj9'
         ],
         'ppc64leLinux': [
-                'temurin'
+                'openj9'
         ],
         's390xLinux'  : [
-                'temurin'
+                'openj9'
         ],
         'aarch64Linux': [
-                'hotspot',
-                'temurin'
+                'openj9'
         ],
         'aarch64Mac': [
-                'temurin'
-        ],
-        'arm32Linux'  : [
-                'hotspot'
-        ],
-        'x32Windows'  : [
-                'hotspot'
+                'openj9'
         ]
 ]
+
+// Weekly 8:00 pm Mon~Thur
+triggerSchedule_nightly = '0 20 * * 1-4'
+// 12:00 pm Sat
+triggerSchedule_weekly = '0 12 * * 6'
 
 // scmReferences to use for weekly release build
 weekly_release_scmReferences = [

--- a/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk23_pipeline_config.groovy
@@ -4,14 +4,21 @@ class Config23 {
         x64Mac    : [
                 os                  : 'mac',
                 arch                : 'x64',
-                additionalNodeLabels: 'xcode15.0.1',
+                additionalNodeLabels: [
+                        openj9      : 'hw.arch.x86 && sw.os.mac.10_15',
+                        temurin     : 'xcode15.0.1'
+                ],
                 additionalTestLabels: [
-                        openj9      : '!sw.os.osx.10_11',
+                        openj9      : '!sw.os.mac.10_15',
                         temurin     : '!sw.os.osx.10_14'
                 ],
                 test                : 'default',
-                configureArgs       : '--enable-dtrace',
+                configureArgs       : [
+                        openj9      : '--enable-dtrace --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
+                        temurin     : '--enable-dtrace'
+                ],
                 buildArgs           : [
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],
@@ -23,18 +30,87 @@ class Config23 {
                 dockerFile: [
                         openj9      : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
-                test: [
-                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'dev.openjdk', 'dev.functional', 'dev.system', 'special.system']
+                dockerNode          : 'sw.tool.docker && sw.config.uid1000',
+                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
+                test                : [
+                        nightly: [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'special.system'
+                        ],
+                        weekly : [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'extended.perf',
+                                'extended.jck',
+                                'extended.system',
+                                'special.functional',
+                                'special.jck',
+                                'special.openjdk',
+                                'special.system',
+                                'dev.functional',
+                                'sanity.external',
+                                'dev.openjdk',
+                                'sanity.functional.fips140_2',
+                                'extended.functional.fips140_2',
+                                'sanity.jck.fips140_2',
+                                'extended.jck.fips140_2',
+                                'special.jck.fips140_2',
+                                'sanity.openjdk.fips140_2',
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
+                        ],
+                        release : [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'extended.perf',
+                                'extended.jck',
+                                'extended.system',
+                                'special.functional',
+                                'special.jck',
+                                'special.openjdk',
+                                'special.system',
+                                'sanity.functional.fips140_2',
+                                'extended.functional.fips140_2',
+                                'sanity.jck.fips140_2',
+                                'extended.jck.fips140_2',
+                                'special.jck.fips140_2',
+                                'sanity.openjdk.fips140_2',
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
+                        ]
+                ],
+                cleanWorkspaceAfterBuild: true,
+                additionalNodeLabels: [
+                        openj9      : 'hw.arch.x86 && sw.os.linux'
                 ],
                 additionalTestLabels: [
-                        openj9      : '!(centos6||rhel6)',
+                        openj9      : '!(sw.os.cent.6||sw.os.rhel.6)',
                         temurin     : '!(centos6||rhel6)'
                 ],
                 configureArgs       : [
-                        'openj9'    : '--enable-dtrace',
+                        'openj9'    : '--enable-dtrace --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
                         'temurin'   : '--enable-dtrace'
                 ],
                 buildArgs           : [
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-source-archive --create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b02'
                 ]
         ],
@@ -64,12 +140,18 @@ class Config23 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: 'win2022&&vs2022',
-                test: [
-                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.functional', 'extended.functional', 'extended.openjdk', 'extended.perf', 'special.functional', 'special.openjdk', 'dev.functional', 'dev.system']
+                additionalNodeLabels: [
+                        openj9      : 'hw.arch.x86 && sw.os.windows',
+                        temurin     : 'win2022&&vs2022'
                 ],
-                configureArgs       : "--with-ucrt-dll-dir='C:/progra~2/wi3cf2~1/10/Redist/10.0.22621.0/ucrt/DLLs/x64'",
+                cleanWorkspaceAfterBuild: true,
+                test                : 'default',
+                configureArgs       : [
+                        openj9      : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-jdk-rc-name="IBM Semeru Runtime"',
+                        temurin     : "--with-ucrt-dll-dir='C:/progra~2/wi3cf2~1/10/Redist/10.0.22621.0/ucrt/DLLs/x64'"
+                ],
                 buildArgs           : [
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],
@@ -79,14 +161,65 @@ class Config23 {
                 arch                : 'ppc64',
                 additionalNodeLabels: [
                         temurin: 'xlc16&&aix720',
-                        openj9:  'xlc16&&aix715'
+                        openj9:  'hw.arch.ppc64 && sw.os.aix.7_2'
                 ],
-                test                : 'default',
+                test                : [
+                        nightly: [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'special.system'
+                        ],
+                        weekly : [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'extended.perf',
+                                'extended.jck',
+                                'extended.system',
+                                'special.functional',
+                                'special.jck',
+                                'special.openjdk',
+                                'special.system',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
+                        ],
+                        release : [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'extended.perf',
+                                'extended.jck',
+                                'extended.system',
+                                'special.functional',
+                                'special.jck',
+                                'special.openjdk',
+                                'special.system',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
+                        ]
+                ],
                 additionalTestLabels: [
                         temurin      : 'sw.os.aix.7_2'
                 ],
                 cleanWorkspaceAfterBuild: true,
+                configureArgs       : [
+                        openj9      : '--disable-ccache --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
+                ],
                 buildArgs           : [
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],
@@ -94,9 +227,84 @@ class Config23 {
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                dockerImage         : 'rhel7_build_image',
-                test                : 'default',
+                test                : [
+                        nightly: [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'special.system'
+                        ],
+                        weekly : [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'extended.perf',
+                                'extended.jck',
+                                'extended.system',
+                                'special.functional',
+                                'special.jck',
+                                'special.openjdk',
+                                'special.system',
+                                'dev.functional',
+                                'sanity.external',
+                                'dev.openjdk',
+                                'sanity.functional.fips140_2',
+                                'extended.functional.fips140_2',
+                                'sanity.jck.fips140_2',
+                                'extended.jck.fips140_2',
+                                'special.jck.fips140_2',
+                                'sanity.openjdk.fips140_2',
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
+                        ],
+                        release : [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'extended.perf',
+                                'extended.jck',
+                                'extended.system',
+                                'special.functional',
+                                'special.jck',
+                                'special.openjdk',
+                                'special.system',
+                                'sanity.functional.fips140_2',
+                                'extended.functional.fips140_2',
+                                'sanity.jck.fips140_2',
+                                'extended.jck.fips140_2',
+                                'special.jck.fips140_2',
+                                'sanity.openjdk.fips140_2',
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
+                        ]
+                ],
+                cleanWorkspaceAfterBuild: true,
+                additionalNodeLabels: [
+                        openj9:  'ci.project.openj9 && hw.arch.s390x'
+                ],
+                dockerImage: 'sys-rt-docker-local/semeru/s390_rhel7_build_image',
+                dockerRegistry: 'https://docker-na.artifactory.swg-devops.com/',
+                dockerCredential : '7c1c2c28-650f-49e0-afd1-ca6b60479546',
+                dockerNode : 'sw.tool.docker',
+                configureArgs       : [
+                        openj9      : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
+                ],
                 buildArgs           : [
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit s390x-on-s390x.RH7'
                 ]
         ],
@@ -104,12 +312,86 @@ class Config23 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
+                test                : [
+                        nightly: [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'special.system'
+                        ],
+                        weekly : [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'extended.perf',
+                                'extended.jck',
+                                'extended.system',
+                                'special.functional',
+                                'special.jck',
+                                'special.openjdk',
+                                'special.system',
+                                'dev.functional',
+                                'sanity.external',
+                                'dev.openjdk',
+                                'sanity.functional.fips140_2',
+                                'extended.functional.fips140_2',
+                                'sanity.jck.fips140_2',
+                                'extended.jck.fips140_2',
+                                'special.jck.fips140_2',
+                                'sanity.openjdk.fips140_2',
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
+                        ],
+                        release : [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'extended.perf',
+                                'extended.jck',
+                                'extended.system',
+                                'special.functional',
+                                'special.jck',
+                                'special.openjdk',
+                                'special.system',
+                                'sanity.functional.fips140_2',
+                                'extended.functional.fips140_2',
+                                'sanity.jck.fips140_2',
+                                'extended.jck.fips140_2',
+                                'special.jck.fips140_2',
+                                'sanity.openjdk.fips140_2',
+                                'extended.openjdk.fips140_2',
+                                'sanity.openjdk.fips140_3_OpenJCEPlusFIPS',
+                                'extended.openjdk.fips140_3_OpenJCEPlusFIPS'
+                        ]
+                ],
+                cleanWorkspaceAfterBuild: true,
+                additionalNodeLabels: [
+                        openj9      : 'ci.project.openj9 && hw.arch.ppc64le && sw.os.linux'
+                ],
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
-                test                : 'default',
+                dockerFile: [
+                    openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
+                ],
+                dockerNode         : 'sw.tool.docker',
+                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 configureArgs       : [
-                        'openj9'      : '--enable-dtrace'
+                        'openj9'    : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                 ],
                 buildArgs           : [
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.9.2009-b02'
                 ]
         ],
@@ -117,10 +399,66 @@ class Config23 {
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
+                additionalNodeLabels: [
+                        openj9      : 'hw.arch.aarch64 && sw.os.linux'
+                ],
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
-                test                : 'default',
-                configureArgs : '--enable-dtrace',
+                dockerNode          : 'sw.tool.docker',
+                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
+                test                : [
+                        nightly: [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'special.system'
+                        ],
+                        weekly : [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'extended.perf',
+                                'extended.jck',
+                                'extended.system',
+                                'special.functional',
+                                'special.jck',
+                                'special.openjdk',
+                                'special.system',
+                                'dev.functional',
+                                'sanity.external',
+                                'dev.openjdk'
+                        ],
+                        release : [
+                                'sanity.functional',
+                                'sanity.openjdk',
+                                'sanity.perf',
+                                'sanity.jck',
+                                'sanity.system',
+                                'extended.functional',
+                                'extended.openjdk',
+                                'extended.perf',
+                                'extended.jck',
+                                'extended.system',
+                                'special.functional',
+                                'special.jck',
+                                'special.openjdk',
+                                'special.system'
+                        ]
+                ],
+                configureArgs : [
+                        'openj9'    : '--enable-dtrace --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
+                        'temurin'   : '--enable-dtrace'
+                ],
+                cleanWorkspaceAfterBuild: true,
                 buildArgs           : [
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom --use-adoptium-devkit gcc-11.3.0-Centos7.6.1810-b02'
                 ]
         ],
@@ -128,9 +466,17 @@ class Config23 {
         aarch64Mac: [
                 os                  : 'mac',
                 arch                : 'aarch64',
-                additionalNodeLabels: 'xcode15.0.1',
+                additionalNodeLabels: [
+                        openj9      : 'hw.arch.aarch64 && sw.os.mac',
+                        temurin     : 'xcode15.0.1'
+                ],
+                cleanWorkspaceAfterBuild: true,
                 test                : 'default',
+                configureArgs       : [
+                        openj9      : '--enable-dtrace --disable-warnings-as-errors --with-noncompressedrefs --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
+                ],
                 buildArgs           : [
+                        'openj9'    : '--create-jre-image --ssh',
                         'temurin'   : '--create-jre-image --create-sbom'
                 ]
         ],


### PR DESCRIPTION
Copied from jdk22 configs. Will keep same schedule since we will be disabling 22.