### PR TITLE
Pull cuda image from nvcr

### DIFF
--- a/pipelines/build/dockerFiles/cuda.dockerfile
+++ b/pipelines/build/dockerFiles/cuda.dockerfile
@@ -2,7 +2,7 @@ ARG image
 ARG cuda_ver=12.2.0
 ARG cuda_distro=ubi8
 
-FROM nvidia/cuda:${cuda_ver}-devel-${cuda_distro} as cuda
+FROM nvcr.io/nvidia/cuda:${cuda_ver}-devel-${cuda_distro} as cuda
 FROM $image
 
 # Install cuda headers https://github.com/eclipse/openj9/blob/master/buildenv/docker/mkdocker.sh#L586-L593


### PR DESCRIPTION
In the event we are rate-limited or restricted from pulling from DockerHub, this should work around the problem by pulling from Nvidia's site.

Issue runtimes/automation/122
Related eclipse-openj9/openj9#20622