### PR TITLE
correct openjceplus `overrideOpenJCEPlusBranch` param in builds

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -1378,6 +1378,7 @@ return {
             aqaReference: aqaReference,
             aqaAutoGen: Boolean.parseBoolean(aqaAutoGen),
             publishName: publishName,
+            openjceplusBranch: openjceplusBranch,
             additionalConfigureArgs: additionalConfigureArgs,
             scmVars: scmVars,
             additionalBuildArgs: additionalBuildArgs,

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2161,7 +2161,9 @@ class Build {
                                     def javaVersion = getJavaVersionNumber()
                                     if (!DEFAULTS_JSON['exclude-openjceplus'].contains(javaVersion)) {
                                         def openjceplusBranch = "semeru-java" + javaVersion.toString()
-                                        if (buildConfig.RELEASE) {
+                                        if (buildConfig.OPENJCEPLUS_BRANCH){
+                                            openjceplusBranch = buildConfig.OPENJCEPLUS_BRANCH
+                                        } else if (buildConfig.RELEASE) {
                                             try {
                                                 def branchSuffix = (buildConfig.PUBLISH_NAME =~ /jdk-([0-9]+(\.[0-9]+){0,3})\+.*/)[ 0 ][ 1 ]
                                                 openjceplusBranch = "semeru-java-" + branchSuffix

--- a/pipelines/defaults.json
+++ b/pipelines/defaults.json
@@ -7,7 +7,7 @@
         "pipeline_branch"    : "ibm",
         "installer_url"      : "git@github.ibm.com:runtimes/adoptium-installer.git",
         "installer_branch"   : "ibm",
-        "helper_ref"         : "master"
+        "helper_ref"         : "ibm"
     },
     "jenkinsDetails"         : {
         "rootUrl"            : "https://hyc-runtimes-jenkins.swg-devops.com/",


### PR DESCRIPTION
connects the param `overrideOpenJCEPlusBranch` to build pipeline and deliver in `BUILD_CONFIGURATION`. Also sets the helper branch to `ibm` which has required changes for openJCEPlus. Related GHE:automation/issues/156

Signed-off-by: mahdi@ibm.com