### PR TITLE
avoid top level pipeline error

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -1159,8 +1159,8 @@ class Builder implements Serializable {
                                         }
 
                                         copyArtifactSuccess = true
-                                        if (release) {
-                                            //def (String releaseToolUrl, String releaseComment) = publishBinary(config)
+                                        if (release && context.JENKINS_URL.contains('adoptium')) {
+                                            def (String releaseToolUrl, String releaseComment) = publishBinary(config)
                                             releaseSummary.appendText("<li><a href=${releaseToolUrl}> ${releaseComment} ${config.VARIANT} ${publishName} ${config.TARGET_OS} ${config.ARCHITECTURE}</a></li>")
                                         }
                                     }
@@ -1186,7 +1186,6 @@ class Builder implements Serializable {
                 }
             }
             context.parallel jobs
-            releaseSummary.appendText('</ul>', false)
 
             if (enableSourceRpm && (!linuxTargets.isEmpty() || !taggedLinuxTargets.isEmpty())) {
                 //build RedHat source RPM package for Linux platforms


### PR DESCRIPTION
It is to cover for the [PR](https://github.com/ibmruntimes/ci-jenkins-pipelines/pull/216/) and avoid `No such property: releaseToolUrl for class: Builder`. Related automation#50

Singned-off-by: mahdi@ibm.com