### PR TITLE
replace os specific labels for mac aarch,x64 with sw.tool.xcode.15_2

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -4,7 +4,7 @@ class Config11 {
         x64Mac    : [
             os                  : 'mac',
             arch                : 'x64',
-            additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.mac.10_15',
+            additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.mac && sw.tool.xcode.15_2',
             test                : 'default',
             configureArgs       : [
                     'openj9'      : '--enable-dtrace=auto  --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
@@ -260,7 +260,7 @@ class Config11 {
                 os                  : 'mac',
                 arch                : 'aarch64',
                 additionalNodeLabels: [
-                        openj9 : 'ci.project.openj9 && hw.arch.aarch64 && sw.os.mac',
+                        openj9 : 'ci.project.openj9 && hw.arch.aarch64 && sw.os.mac && sw.tool.xcode.15_2',
                         temurin: 'macos11'
                 ],
                 cleanWorkspaceAfterBuild: true,
@@ -328,7 +328,7 @@ class Config11 {
         x64MacIBM    : [
             os                  : 'mac',
             arch                : 'x64',
-            additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.mac.10_15',
+            additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.mac && sw.tool.xcode.15_2',
             test                : 'default',
             configureArgs       : [
                     'openj9'      : '--enable-dtrace=auto '
@@ -791,7 +791,7 @@ class Config11 {
                 os                  : 'mac',
                 arch                : 'aarch64',
                 additionalNodeLabels: [
-                        openj9 : 'ci.project.openj9 && hw.arch.aarch64 && sw.os.mac'
+                        openj9 : 'ci.project.openj9 && hw.arch.aarch64 && sw.os.mac && sw.tool.xcode.15_2'
                 ],
                 cleanWorkspaceAfterBuild: true,
                 configureArgs       : [

--- a/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17u_pipeline_config.groovy
@@ -4,9 +4,9 @@ class Config17 {
         x64Mac    : [
                 os                  : 'mac',
                 arch                : 'x64',
-                additionalNodeLabels: 'ci.project.openj9 && hw.arch.x86 && sw.os.mac.10_15',
+                additionalNodeLabels: 'ci.project.openj9 && hw.arch.x86 && sw.os.mac && sw.tool.xcode.15_2',
                 additionalTestLabels: [
-                        openj9      : '!sw.os.mac.10_11'
+                        openj9      : ''
                 ],
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
@@ -199,7 +199,7 @@ class Config17 {
                 arch                : 'aarch64',
                 additionalNodeLabels: [
                         temurin : 'xcode15.0.1',
-                        openj9 : 'ci.project.openj9 && hw.arch.aarch64 && sw.os.mac'
+                        openj9 : 'ci.project.openj9 && hw.arch.aarch64 && sw.os.mac && sw.tool.xcode.15_2'
                 ],
                 cleanWorkspaceAfterBuild: true,
                 configureArgs       : [
@@ -258,7 +258,7 @@ class Config17 {
         x64MacIBM    : [
                 os                  : 'mac',
                 arch                : 'x64',
-                additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.mac.10_15',
+                additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.mac && sw.tool.xcode.15_2',
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
                 configureArgs       : [
@@ -726,7 +726,7 @@ class Config17 {
                 arch                : 'aarch64',
                 additionalNodeLabels: [
                         temurin : 'macos11',
-                        openj9 : 'ci.project.openj9 && hw.arch.aarch64 && sw.os.mac'
+                        openj9 : 'ci.project.openj9 && hw.arch.aarch64 && sw.os.mac && sw.tool.xcode.15_2'
                 ],
                 cleanWorkspaceAfterBuild: true,
                 configureArgs       : [

--- a/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk21u_pipeline_config.groovy
@@ -5,11 +5,11 @@ class Config21 {
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels: [
-                        openj9      : 'hw.arch.x86 && sw.os.mac.10_15',
+                        openj9      : 'ci.project.openj9 && hw.arch.x86 && sw.os.mac && sw.tool.xcode.15_2',
                         temurin     : 'xcode15.0.1'
                 ],
                 additionalTestLabels: [
-                        openj9      : '!sw.os.mac.10_11'
+                        openj9      : ''
                 ],
                 test                : 'default',
                 configureArgs       : [
@@ -183,7 +183,7 @@ class Config21 {
                 os                  : 'mac',
                 arch                : 'aarch64',
                 additionalNodeLabels: [
-                        openj9      : 'hw.arch.aarch64 && sw.os.mac',
+                        openj9      : 'ci.project.openj9 && hw.arch.aarch64 && sw.os.mac && sw.tool.xcode.15_2',
                         temurin     : 'xcode15.0.1'
                 ],
                 cleanWorkspaceAfterBuild: true,
@@ -224,8 +224,8 @@ class Config21 {
         x64MacIBM    : [
                 os                  : 'mac',
                 arch                : 'x64',
-                additionalNodeLabels: 'hw.arch.x86 && sw.os.mac.10_15',
-                additionalTestLabels: '!sw.os.mac.10_11',
+                additionalNodeLabels: 'ci.project.openj9 && hw.arch.x86 && sw.os.mac && sw.tool.xcode.15_2',
+                additionalTestLabels: '',
                 test                : 'default',
                 configureArgs       : '--enable-dtrace',
                 additionalFileNameTag: 'IBM',
@@ -669,7 +669,7 @@ class Config21 {
         aarch64MacIBM: [
                 os                  : 'mac',
                 arch                : 'aarch64',
-                additionalNodeLabels: 'hw.arch.aarch64 && sw.os.mac',
+                additionalNodeLabels: 'ci.project.openj9 && hw.arch.aarch64 && sw.os.mac && sw.tool.xcode.15_2',
                 cleanWorkspaceAfterBuild: true,
                 test                : 'default',
                 configureArgs       : '--enable-dtrace --disable-warnings-as-errors --with-noncompressedrefs',

--- a/pipelines/jobs/configurations/jdk24_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk24_pipeline_config.groovy
@@ -5,11 +5,11 @@ class Config24 {
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels: [
-                        openj9      : 'hw.arch.x86 && sw.os.mac.10_15',
+                        openj9      : 'ci.project.openj9 && hw.arch.x86 && sw.os.mac && sw.tool.xcode.15_2',
                         temurin     : 'xcode15.0.1'
                 ],
                 additionalTestLabels: [
-                        openj9      : '!sw.os.mac.10_15',
+                        openj9      : '',
                         temurin     : '!sw.os.osx.10_14'
                 ],
                 test                : 'default',
@@ -524,7 +524,7 @@ class Config24 {
                 os                  : 'mac',
                 arch                : 'aarch64',
                 additionalNodeLabels: [
-                        openj9      : 'hw.arch.aarch64 && sw.os.mac',
+                        openj9      : 'ci.project.openj9 && hw.arch.aarch64 && sw.os.mac && sw.tool.xcode.15_2',
                         temurin     : 'xcode15.0.1'
                 ],
                 cleanWorkspaceAfterBuild: true,

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -6,7 +6,7 @@ class Config8 {
                 arch                : 'x64',
                 additionalNodeLabels: [
                         temurin : 'xcode11.7',
-                        openj9  : 'ci.project.openj9 && hw.arch.x86 && sw.os.mac.10_15'
+                        openj9  : 'ci.project.openj9 && hw.arch.x86 && sw.os.mac && sw.tool.xcode.15_2'
                 ],
                 cleanWorkspaceAfterBuild: true,
                 test                 : 'default',


### PR DESCRIPTION
Related changes to build base on XCode level rather os specified version. related: runtimes/infrastructure#8105. Also unnecessary additionalTestLables removed.

Sigend-off-by: mahdi@ibm.com