### PR TITLE
Remove obsolete label sw.config.uid1000

### DIFF
--- a/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
@@ -27,7 +27,7 @@ class Config17 {
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
-                dockerNode          : 'sw.tool.docker && sw.config.uid1000',
+                dockerNode          : 'sw.tool.docker',
                 dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
@@ -255,7 +255,7 @@ class Config17 {
                 dockerFile: [
                         'openj9'  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
-                dockerNode          : 'sw.tool.docker && sw.config.uid1000',
+                dockerNode          : 'sw.tool.docker',
                 dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : [
                         nightly: [

--- a/pipelines/jobs/Semeru_configuration/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk21u_pipeline_config.groovy
@@ -28,7 +28,7 @@ class Config21 {
                 dockerFile: [
                         openj9      : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
-                dockerNode          : 'sw.tool.docker && sw.config.uid1000',
+                dockerNode          : 'sw.tool.docker',
                 dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
@@ -222,7 +222,7 @@ class Config21 {
                 arch                : 'x64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 dockerFile          : 'pipelines/build/dockerFiles/cuda.dockerfile',
-                dockerNode          : 'sw.tool.docker && sw.config.uid1000',
+                dockerNode          : 'sw.tool.docker',
                 dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : [
                         nightly: [

--- a/pipelines/jobs/Semeru_configuration/jdk24_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk24_pipeline_config.groovy
@@ -29,7 +29,7 @@ class Config24 {
                 dockerFile: [
                         openj9      : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
-                dockerNode          : 'sw.tool.docker && sw.config.uid1000',
+                dockerNode          : 'sw.tool.docker',
                 dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : [
                         nightly: [


### PR DESCRIPTION
Removes label sw.config.uid1000 as now uid1000 built into the build machine playbooks. Related https://github.ibm.com/runtimes/automation/issues/334

Signed-off-by: mahdi@ibm.com