### PR TITLE
Update docker images to use Adoptium for multiple JDK config on ghcr.io

### DIFF
--- a/pipelines/jobs/Semeru_configuration/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk11u_pipeline_config.groovy
@@ -1,6 +1,6 @@
 class Config11 {
 
-    final Map<String, Map<String, ?>> buildConfigurations = [
+        final Map<String, Map<String, ?>> buildConfigurations = [
         x64Mac    : [
             os                  : 'mac',
             arch                : 'x64',
@@ -17,13 +17,14 @@ class Config11 {
         x64Linux  : [
             os                  : 'linux',
             arch                : 'x64',
-            additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
-            dockerImage         : 'adoptopenjdk/centos6_build_image',
+            dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos6_linux-amd64',
+            dockerRegistry      : 'https://ghcr.io/',
+            dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
             dockerFile: [
                     openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
             ],
+            additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
             dockerNode          : 'sw.tool.docker',
-            dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
             test                : 'default',
             configureArgs       : [
                     'openj9'      : '--disable-ccache --enable-dtrace=auto --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
@@ -96,15 +97,16 @@ class Config11 {
             os                  : 'linux',
             arch                : 'ppc64le',
             test                : 'default',
+            dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+            dockerRegistry      : 'https://ghcr.io/',
+            dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
             additionalNodeLabels: [
                     openj9:  'ci.project.openj9 && hw.arch.ppc64le && sw.os.linux'
             ],
-            dockerImage         : 'adoptopenjdk/centos7_build_image',
             dockerFile: [
                     openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
             ],
             dockerNode         : 'sw.tool.docker',
-            dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
             configureArgs       : [
                     'openj9'      : '--enable-dtrace=auto --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
             ],
@@ -116,9 +118,10 @@ class Config11 {
         aarch64Linux    : [
             os                  : 'linux',
             arch                : 'aarch64',
-            dockerImage         : 'adoptopenjdk/centos7_build_image',
+            dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+            dockerRegistry      : 'https://ghcr.io/',
+            dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
             dockerNode         : 'sw.tool.docker',
-            dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
             additionalNodeLabels: [
                     openj9:  'hw.arch.aarch64 && sw.os.linux'
             ],
@@ -139,14 +142,15 @@ class Config11 {
             arch                 : 'riscv64',
             dockerImage          : [
                     'hotspot'    : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
-                    'openj9'     : 'adoptopenjdk/centos6_build_image',
+                    'openj9'     : 'ghcr.io/adoptium/adoptium_build_image:ubuntu2004_linux-riscv64',
                     'bisheng'    : 'adoptopenjdk/centos6_build_image'
             ],
+            dockerRegistry      : 'https://ghcr.io/',
+            dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
             dockerArgs           : [
                     'hotspot'    : '--platform linux/riscv64'
             ],
             dockerNode         : 'sw.tool.docker',
-            dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
             crossCompile         : [
                     'hotspot'    : 'dockerhost-rise-ubuntu2204-aarch64-1',
                     'openj9'     : 'x64',
@@ -183,7 +187,7 @@ class Config11 {
                 configureArgs       : [
                         'openj9'    : '--enable-dtrace --disable-warnings-as-errors --with-noncompressedrefs --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
                         'corretto'  : '--enable-dtrace=auto',
-                        'dragonwell': "--enable-dtrace=auto --with-extra-cflags=\"-march=armv8.2-a+crypto\" --with-extra-cxxflags=\"-march=armv8.2-a+crypto\"",
+                        'dragonwell': '--enable-dtrace=auto --with-extra-cflags=\"-march=armv8.2-a+crypto\" --with-extra-cxxflags=\"-march=armv8.2-a+crypto\"',
                         'bisheng'   : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server'
                 ],
                 test                : [
@@ -209,13 +213,14 @@ class Config11 {
         x64LinuxIBM  : [
             os                  : 'linux',
             arch                : 'x64',
-            additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
-            dockerImage         : 'adoptopenjdk/centos6_build_image',
+            dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos6_linux-amd64',
+            dockerRegistry      : 'https://ghcr.io/',
+            dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
             dockerFile: [
                     'openj9'  : 'pipelines/build/dockerFiles/cuda.dockerfile'
             ],
             dockerNode          : 'sw.tool.docker',
-            dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
+            additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
             test                : [
                     nightly: [
                         'sanity.functional',
@@ -316,7 +321,7 @@ class Config11 {
                         'extended.openjdk',
                         'special.system'
                     ],
-                    weekly : [     
+                    weekly : [
                         'sanity.functional',
                         'sanity.openjdk',
                         'sanity.perf',
@@ -510,6 +515,13 @@ class Config11 {
         ppc64leLinuxIBM    : [
             os                  : 'linux',
             arch                : 'ppc64le',
+            dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+            dockerRegistry      : 'https://ghcr.io/',
+            dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+            dockerFile: [
+                    openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
+            ],
+            dockerNode         : 'sw.tool.docker',
             test                : [
                     nightly: [
                         'sanity.functional',
@@ -580,12 +592,6 @@ class Config11 {
             additionalNodeLabels: [
                     openj9:  'ci.project.openj9 && hw.arch.ppc64le && sw.os.linux'
             ],
-            dockerImage         : 'adoptopenjdk/centos7_build_image',
-            dockerFile: [
-                    openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
-            ],
-            dockerNode         : 'sw.tool.docker',
-            dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
             configureArgs       : [
                         'openj9'      : '--enable-dtrace=auto'
             ],
@@ -596,9 +602,10 @@ class Config11 {
         aarch64LinuxIBM    : [
             os                  : 'linux',
             arch                : 'aarch64',
-            dockerImage         : 'adoptopenjdk/centos7_build_image',
+            dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+            dockerRegistry      : 'https://ghcr.io/',
+            dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
             dockerNode         : 'sw.tool.docker',
-            dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
             additionalNodeLabels: [
                     openj9:  'hw.arch.aarch64 && sw.os.linux'
             ],
@@ -631,7 +638,7 @@ class Config11 {
                         'dev.functional',
                         'sanity.external',
                         'dev.external',
-                        'dev.openjdk'                        
+                        'dev.openjdk'
                     ],
                     release : [
                         'sanity.functional',

--- a/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
@@ -19,16 +19,17 @@ class Config17 {
         x64Linux  : [
                 os                  : 'linux',
                 arch                : 'x64',
-                additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
                 dockerImage: [
                         temurin     : 'adoptopenjdk/centos6_build_image',
-                        openj9      : 'adoptopenjdk/centos7_build_image'
+                        openj9      : 'ghcr.io/adoptium/adoptium_build_image:centos7'
                 ],
+                dockerRegistry: 'https://ghcr.io/',
+                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 dockerNode          : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
                 additionalTestLabels: [
@@ -100,17 +101,18 @@ class Config17 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+                dockerRegistry      : 'https://ghcr.io/',
+                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
                 additionalNodeLabels: [
                     openj9:  'ci.project.openj9 && hw.arch.ppc64le && sw.os.linux'
                 ],
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
                 dockerFile: [
                     openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 dockerNode         : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 buildArgs           : [
                         'openj9'    : '--create-jre-image --ssh'
                         ],
@@ -122,9 +124,10 @@ class Config17 {
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+                dockerRegistry      : 'https://ghcr.io/',
+                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
                 dockerNode         : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : 'default',
                 additionalNodeLabels: [
                         openj9:  'hw.arch.aarch64 && sw.os.linux'
@@ -160,8 +163,8 @@ class Config17 {
         riscv64Linux      :  [
                 os                  : 'linux',
                 arch                : 'riscv64',
-                crossCompile        : 'qemustatic',
                 dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
+                crossCompile        : 'qemustatic',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
                 configureArgs       : '--enable-headless-only=yes --enable-dtrace',
@@ -185,13 +188,14 @@ class Config17 {
         x64LinuxIBM  : [
                 os                  : 'linux',
                 arch                : 'x64',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+                dockerRegistry      : 'https://ghcr.io/',
+                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
                 additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
                 dockerFile: [
                         'openj9'  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 dockerNode          : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : [
                         nightly: [
                                 'sanity.functional',
@@ -485,6 +489,9 @@ class Config17 {
         ppc64leLinuxIBM    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+                dockerRegistry      : 'https://ghcr.io/',
+                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
                 test                : [
                         nightly: [
                                 'sanity.functional',
@@ -555,12 +562,10 @@ class Config17 {
                 additionalNodeLabels: [
                     openj9:  'ci.project.openj9 && hw.arch.ppc64le && sw.os.linux'
                 ],
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
                 dockerFile: [
                     openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 dockerNode         : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 configureArgs       : [
                         'openj9'      : ''
                 ],
@@ -571,9 +576,10 @@ class Config17 {
         aarch64LinuxIBM    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+                dockerRegistry      : 'https://ghcr.io/',
+                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
                 dockerNode         : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : [
                         nightly: [
                                 'sanity.functional',

--- a/pipelines/jobs/Semeru_configuration/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk21u_pipeline_config.groovy
@@ -24,12 +24,13 @@ class Config21 {
         x64Linux  : [
                 os                  : 'linux',
                 arch                : 'x64',
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+                dockerRegistry      : 'https://ghcr.io/',
+                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
                 dockerFile: [
                         openj9      : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 dockerNode          : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
                 additionalNodeLabels: [
@@ -107,17 +108,18 @@ class Config21 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+                dockerRegistry      : 'https://ghcr.io/',
+                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
                 additionalNodeLabels: [
                     openj9:  'ci.project.openj9 && hw.arch.ppc64le && sw.os.linux'
                 ],
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
                 dockerFile: [
                     openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 dockerNode         : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 configureArgs       : [
                         'openj9'    : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                 ],
@@ -129,12 +131,13 @@ class Config21 {
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+                dockerRegistry      : 'https://ghcr.io/',
+                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerNode          : 'sw.tool.docker',
                 additionalNodeLabels: [
                         openj9      : 'hw.arch.aarch64 && sw.os.linux'
                 ],
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
-                dockerNode          : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : 'default',
                 configureArgs : [
                         'openj9'    : '--enable-dtrace --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
@@ -166,7 +169,7 @@ class Config21 {
                 os                  : 'linux',
                 arch                : 'riscv64',
                 crossCompile        : 'qemustatic',
-                dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:ubuntu2004_linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
                 configureArgs       : '--enable-headless-only=yes --enable-dtrace',
@@ -188,10 +191,11 @@ class Config21 {
         x64LinuxIBM  : [
                 os                  : 'linux',
                 arch                : 'x64',
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+                dockerRegistry      : 'https://ghcr.io/',
+                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
                 dockerFile          : 'pipelines/build/dockerFiles/cuda.dockerfile',
                 dockerNode          : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : [
                         nightly: [
                                 'sanity.functional',
@@ -476,6 +480,13 @@ class Config21 {
         ppc64leLinuxIBM    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+                dockerRegistry      : 'https://ghcr.io/',
+                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerFile: [
+                    openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
+                ],
+                dockerNode         : 'sw.tool.docker',
                 test                : [
                         nightly: [
                                 'sanity.functional',
@@ -547,12 +558,6 @@ class Config21 {
                 additionalNodeLabels: [
                     openj9:  'ci.project.openj9 && hw.arch.ppc64le && sw.os.linux'
                 ],
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
-                dockerFile: [
-                    openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
-                ],
-                dockerNode         : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 additionalFileNameTag: 'IBM',
                 buildArgs           : '--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk21 -b ibm_sdk --create-jre-image'
         ],
@@ -560,10 +565,11 @@ class Config21 {
         aarch64LinuxIBM    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
-                additionalNodeLabels: 'hw.arch.aarch64 && sw.os.linux',
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+                dockerRegistry      : 'https://ghcr.io/',
+                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
                 dockerNode          : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
+                additionalNodeLabels: 'hw.arch.aarch64 && sw.os.linux',
                 test                : [
                         nightly: [
                                 'sanity.functional',

--- a/pipelines/jobs/Semeru_configuration/jdk24_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk24_pipeline_config.groovy
@@ -25,12 +25,13 @@ class Config24 {
         x64Linux  : [
                 os                  : 'linux',
                 arch                : 'x64',
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+                dockerRegistry      : 'https://ghcr.io/',
+                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
                 dockerFile: [
                         openj9      : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 dockerNode          : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : [
                         nightly: [
                                 'sanity.functional',
@@ -338,6 +339,13 @@ class Config24 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+                dockerRegistry      : 'https://ghcr.io/',
+                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerFile: [
+                    openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
+                ],
+                dockerNode         : 'sw.tool.docker',
                 test                : [
                         nightly: [
                                 'sanity.functional',
@@ -407,12 +415,6 @@ class Config24 {
                 additionalNodeLabels: [
                         openj9      : 'ci.project.openj9 && hw.arch.ppc64le && sw.os.linux'
                 ],
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
-                dockerFile: [
-                    openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
-                ],
-                dockerNode         : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 configureArgs       : [
                         'openj9'    : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                 ],
@@ -424,12 +426,13 @@ class Config24 {
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+                dockerRegistry      : 'https://ghcr.io/',
+                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerNode          : 'sw.tool.docker',
                 additionalNodeLabels: [
                         openj9      : 'hw.arch.aarch64 && sw.os.linux'
                 ],
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
-                dockerNode          : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 test                : [
                         nightly: [
                                 'sanity.functional',
@@ -507,7 +510,7 @@ class Config24 {
                 os                  : 'linux',
                 arch                : 'riscv64',
                 crossCompile        : 'qemustatic',
-                dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:ubuntu2004_linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
                 test                : 'default',
                 configureArgs       : '--enable-headless-only=yes --enable-dtrace',

--- a/pipelines/jobs/Semeru_configuration/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk8u_pipeline_config.groovy
@@ -21,14 +21,15 @@ class Config8 {
         x64Linux      : [
                 os                  : 'linux',
                 arch                : 'x64',
-                additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
-                dockerImage         : 'adoptopenjdk/centos6_build_image',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos6',
+                dockerRegistry      : 'https://ghcr.io/',
+                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile',
                         dragonwell: 'pipelines/build/dockerFiles/dragonwell.dockerfile'
                 ],
                 dockerNode          : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
+                additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
                 test                : [
                         nightly: [
                                 'sanity.functional',
@@ -290,12 +291,12 @@ class Config8 {
                 additionalNodeLabels: [
                         openj9:  'ci.project.openj9 && hw.arch.ppc64le && sw.os.linux'
                 ],
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
                 dockerFile: [
                     openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 dockerNode         : 'sw.tool.docker',
-                dockerCredential : '9f50c848-8764-440d-b95a-1d295c21713e',
+                dockerCredential : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
                 configureArgs       : [
                         'openj9'      : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                         ],
@@ -308,12 +309,13 @@ class Config8 {
         aarch64Linux  : [
                 os                  : 'linux',
                 arch                : 'aarch64',
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
+                dockerRegistry      : 'https://ghcr.io/',
+                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
                 dockerFile: [
                         dragonwell: 'pipelines/build/dockerFiles/dragonwell_aarch64.dockerfile'
                 ],
                 dockerNode         : 'sw.tool.docker',
-                dockerCredential    : '9f50c848-8764-440d-b95a-1d295c21713e',
                 additionalNodeLabels: [
                         openj9:  'hw.arch.aarch64 && sw.os.linux'
                 ],


### PR DESCRIPTION
following new docker hub policy to charge for pull, this is to change pulls to ghcr.io. related https://github.com/adoptium/infrastructure/issues/3830

Signed-off-by: mahdi@ibm.com