### PR TITLE
Allow test images to be downloaded for extended.system

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -502,7 +502,9 @@ class Build {
                             // Keep test reportdir always for JUnit targets
                             keep_test_reportdir = true
                         }
-
+                        if ("${testType}".contains('extended.system')) {
+                            customizedSdkUrl += " " + testimageUrl
+                        }
                         if ("${testType}".contains('dev')) {
                             rerunIterations = '0'
                         }


### PR DESCRIPTION
- Allow test images to be downloaded  for extended.system

related:https://github.ibm.com/runtimes/backlog/issues/1679