### PR TITLE
Login to nvcr instead of ghcr

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2518,7 +2518,7 @@ class Build {
                                                     context.docker.image(buildConfig.DOCKER_IMAGE).pull()
                                                 }
                                             }
-                                            // When we use non-default registery, we need to add a tag includes that inorder to let in later lines be able to access image and fetch `dockerImageDigest` 
+                                            // When we use non-default registry, we need to add a tag that includes the registry name in order to be able to access the image and fetch `dockerImageDigest`
                                             def imageWithoutTag = buildConfig.DOCKER_IMAGE.contains(':') ? buildConfig.DOCKER_IMAGE.substring(0, buildConfig.DOCKER_IMAGE.lastIndexOf(':')) : buildConfig.DOCKER_IMAGE
                                             def imageTag = buildConfig.DOCKER_IMAGE.contains(':') ? buildConfig.DOCKER_IMAGE.substring(buildConfig.DOCKER_IMAGE.lastIndexOf(':') + 1) : 'latest'
                                             def long_docker_image_name = context.sh(script: "docker image ls | grep ${imageWithoutTag} | head -n1 | awk '{print \$1}'", returnStdout:true).trim()

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2515,7 +2515,7 @@ class Build {
                                                 if (buildConfig.DOCKER_ARGS) {
                                                     context.sh(script: "docker pull ${buildConfig.DOCKER_IMAGE} ${buildConfig.DOCKER_ARGS}")
                                                 } else {
-                                                    context.docker.image(buildConfig.DOCKER_IMAGE).pull()
+                                                    context.sh(script: "docker pull ${buildConfig.DOCKER_IMAGE}")
                                                 }
                                             }
                                             // When we use non-default registry, we need to add a tag that includes the registry name in order to be able to access the image and fetch `dockerImageDigest`

--- a/pipelines/jobs/Semeru_configuration/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk11u_pipeline_config.groovy
@@ -18,8 +18,8 @@ class Config11 {
             os                  : 'linux',
             arch                : 'x64',
             dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos6_linux-amd64',
-            dockerRegistry      : 'https://ghcr.io/',
-            dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+            dockerRegistry      : 'https://nvcr.io',
+            dockerCredential    : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
             dockerFile: [
                     openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
             ],
@@ -98,8 +98,8 @@ class Config11 {
             arch                : 'ppc64le',
             test                : 'default',
             dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
-            dockerRegistry      : 'https://ghcr.io/',
-            dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+            dockerRegistry      : 'https://nvcr.io',
+            dockerCredential    : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
             additionalNodeLabels: [
                     openj9:  'ci.project.openj9 && hw.arch.ppc64le && sw.os.linux'
             ],
@@ -214,8 +214,8 @@ class Config11 {
             os                  : 'linux',
             arch                : 'x64',
             dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos6_linux-amd64',
-            dockerRegistry      : 'https://ghcr.io/',
-            dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+            dockerRegistry      : 'https://nvcr.io',
+            dockerCredential    : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
             dockerFile: [
                     'openj9'  : 'pipelines/build/dockerFiles/cuda.dockerfile'
             ],
@@ -353,8 +353,8 @@ class Config11 {
             os                  : 'linux',
             arch                : 'ppc64le',
             dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
-            dockerRegistry      : 'https://ghcr.io/',
-            dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+            dockerRegistry      : 'https://nvcr.io',
+            dockerCredential    : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
             dockerFile: [
                     openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
             ],

--- a/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
@@ -23,8 +23,8 @@ class Config17 {
                         temurin     : 'adoptopenjdk/centos6_build_image',
                         openj9      : 'ghcr.io/adoptium/adoptium_build_image:centos7'
                 ],
-                dockerRegistry: 'https://ghcr.io/',
-                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerRegistry: 'https://nvcr.io',
+                dockerCredential    : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
                 additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
@@ -102,8 +102,8 @@ class Config17 {
                 os                  : 'linux',
                 arch                : 'ppc64le',
                 dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
-                dockerRegistry      : 'https://ghcr.io/',
-                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerRegistry      : 'https://nvcr.io',
+                dockerCredential    : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
                 additionalNodeLabels: [
@@ -189,8 +189,8 @@ class Config17 {
                 os                  : 'linux',
                 arch                : 'x64',
                 dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
-                dockerRegistry      : 'https://ghcr.io/',
-                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerRegistry      : 'https://nvcr.io',
+                dockerCredential    : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
                 additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
                 dockerFile: [
                         'openj9'  : 'pipelines/build/dockerFiles/cuda.dockerfile'
@@ -490,8 +490,8 @@ class Config17 {
                 os                  : 'linux',
                 arch                : 'ppc64le',
                 dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
-                dockerRegistry      : 'https://ghcr.io/',
-                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerRegistry      : 'https://nvcr.io',
+                dockerCredential    : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
                 test                : [
                         nightly: [
                                 'sanity.functional',

--- a/pipelines/jobs/Semeru_configuration/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk21u_pipeline_config.groovy
@@ -25,8 +25,8 @@ class Config21 {
                 os                  : 'linux',
                 arch                : 'x64',
                 dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
-                dockerRegistry      : 'https://ghcr.io/',
-                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerRegistry      : 'https://nvcr.io',
+                dockerCredential    : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
                 dockerFile: [
                         openj9      : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
@@ -109,8 +109,8 @@ class Config21 {
                 os                  : 'linux',
                 arch                : 'ppc64le',
                 dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
-                dockerRegistry      : 'https://ghcr.io/',
-                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerRegistry      : 'https://nvcr.io',
+                dockerCredential    : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
                 test                : 'default',
                 cleanWorkspaceAfterBuild: true,
                 additionalNodeLabels: [
@@ -192,8 +192,8 @@ class Config21 {
                 os                  : 'linux',
                 arch                : 'x64',
                 dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
-                dockerRegistry      : 'https://ghcr.io/',
-                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerRegistry      : 'https://nvcr.io',
+                dockerCredential    : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
                 dockerFile          : 'pipelines/build/dockerFiles/cuda.dockerfile',
                 dockerNode          : 'sw.tool.docker',
                 test                : [
@@ -481,8 +481,8 @@ class Config21 {
                 os                  : 'linux',
                 arch                : 'ppc64le',
                 dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
-                dockerRegistry      : 'https://ghcr.io/',
-                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerRegistry      : 'https://nvcr.io',
+                dockerCredential    : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
                 dockerFile: [
                     openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],

--- a/pipelines/jobs/Semeru_configuration/jdk25_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk25_pipeline_config.groovy
@@ -15,8 +15,8 @@ class Config25 {
                 os                  : 'linux',
                 arch                : 'x64',
                 dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
-                dockerRegistry      : 'https://ghcr.io/',
-                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerRegistry      : 'https://nvcr.io',
+                dockerCredential    : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
                 dockerFile          : 'pipelines/build/dockerFiles/cuda.dockerfile',
                 dockerNode          : 'sw.tool.docker',
                 test                : [
@@ -293,8 +293,8 @@ class Config25 {
                 os                  : 'linux',
                 arch                : 'ppc64le',
                 dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
-                dockerRegistry      : 'https://ghcr.io/',
-                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerRegistry      : 'https://nvcr.io',
+                dockerCredential    : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
                 dockerFile          : 'pipelines/build/dockerFiles/cuda.dockerfile',
                 dockerNode         : 'sw.tool.docker',
                 test                : [
@@ -453,8 +453,8 @@ class Config25 {
                 os                  : 'linux',
                 arch                : 'x64',
                 dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
-                dockerRegistry      : 'https://ghcr.io/',
-                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerRegistry      : 'https://nvcr.io',
+                dockerCredential    : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
                 dockerFile          : 'pipelines/build/dockerFiles/cuda.dockerfile',
                 dockerNode          : 'sw.tool.docker',
                 test                : [
@@ -734,8 +734,8 @@ class Config25 {
                 os                  : 'linux',
                 arch                : 'ppc64le',
                 dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
-                dockerRegistry      : 'https://ghcr.io/',
-                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerRegistry      : 'https://nvcr.io',
+                dockerCredential    : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
                 dockerFile          : 'pipelines/build/dockerFiles/cuda.dockerfile',
                 dockerNode         : 'sw.tool.docker',
                 test                : [

--- a/pipelines/jobs/Semeru_configuration/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk8u_pipeline_config.groovy
@@ -22,8 +22,8 @@ class Config8 {
                 os                  : 'linux',
                 arch                : 'x64',
                 dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos6',
-                dockerRegistry      : 'https://ghcr.io/',
-                dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerRegistry      : 'https://nvcr.io',
+                dockerCredential    : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile',
                         dragonwell: 'pipelines/build/dockerFiles/dragonwell.dockerfile'
@@ -231,12 +231,12 @@ class Config8 {
                 os  : 'linux',
                 arch: 'ppc64le',
                 dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
-                dockerRegistry      : 'https://ghcr.io/',
+                dockerRegistry      : 'https://nvcr.io',
                 dockerFile: [
                     openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 dockerNode         : 'sw.tool.docker',
-                dockerCredential : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
+                dockerCredential : '190cfe9d-f1e6-4757-83ea-11ca21498c84',
                 test                : [
                         nightly: [
                                 'sanity.functional',


### PR DESCRIPTION
On x,p linux when pulling the cuda image
we are hitting an intermittent 401. This is
an attempt to avoid that by logging into nvcr

Issue automation 581

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>

Shell out for docker pull

With the docker.image.pull step, the registry
will be added as a prefix to the image name. If
the registry in use is different then the image,
the prefix will be incorrect. Instead, swap out
to shell and run the docker pull directly.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>