### PR TITLE
Enable EBC for Semeru 17 AQA test

### DIFF
--- a/pipelines/semeru_defaults.json
+++ b/pipelines/semeru_defaults.json
@@ -113,7 +113,7 @@
             "linux_x64" : {
                 "8" :  ["sanity.perf"],
                 "11" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system"],
-                "17" : ["sanity.perf"],
+                "17" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system"],
                 "21" : ["sanity.perf"],
                 "25" : ["sanity.perf"]
             },


### PR DESCRIPTION
EBC is already enabled for Semeru11 test nodes. This now enables Semeru 17. related: automation/issues/374

Signed-off-by: mahdi@ibm.com