### PR TITLE
Enable EBC for Semeru 21 AQA test

### DIFF
--- a/pipelines/semeru_defaults.json
+++ b/pipelines/semeru_defaults.json
@@ -114,7 +114,7 @@
                 "8" :  ["sanity.perf"],
                 "11" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system"],
                 "17" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system"],
-                "21" : ["sanity.perf"],
+                "21" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system"],
                 "25" : ["sanity.perf"]
             },
             "aix_ppc64" : {


### PR DESCRIPTION
EBC is already enabled for Semeru11,17 test nodes. This now enables Semeru 21. related: automation/issues/374

Signed-off-by: mahdi@ibm.com