### PR TITLE
Keep artifacts for 5 builds

### DIFF
--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -62,7 +62,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
 
     logRotator {
         numToKeep(60)
-        artifactNumToKeep(2)
+        artifactNumToKeep(5)
     }
 
     properties {


### PR DESCRIPTION
Since we no longer keep release builds indefinitely, we've hit an issue where 3 builds were running and we lost the artifacts for the 3rd one before they could be archived to the release repo. This increases the limit to 5 to avoid that situation.

Related #293