### PR TITLE
Enable EBC for Semeru 8,25 AQA test

### DIFF
--- a/pipelines/semeru_defaults.json
+++ b/pipelines/semeru_defaults.json
@@ -111,11 +111,11 @@
         },
         "ebcEnabledTargets":{
             "linux_x64" : {
-                "8" :  ["sanity.perf"],
+                "8" :  ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system"],
                 "11" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system"],
                 "17" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system"],
                 "21" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system"],
-                "25" : ["sanity.perf"]
+                "25" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system"]
             },
             "aix_ppc64" : {
                 "8" :  [],


### PR DESCRIPTION
EBC is already enabled for Semeru11,17,21 test nodes. This now enables Semeru 21. related: automation/issues/374

Signed-off-by: mahdi@ibm.com