### PR TITLE
add all test targets proofed to work with EBC-linux-x64

### DIFF
--- a/pipelines/semeru_defaults.json
+++ b/pipelines/semeru_defaults.json
@@ -117,11 +117,11 @@
         },
         "ebcEnabledTargets":{
             "linux_x64" : {
-                "8" :  ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system"],
-                "11" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system"],
-                "17" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system"],
-                "21" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system"],
-                "25" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system"]
+                "8" :  ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system","extended.jck","extended.perf","extended.system","special.functional","special.jck","special.openjdk"],
+                "11" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system","extended.jck","extended.perf","extended.system","special.functional","special.jck","special.openjdk"],
+                "17" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system","extended.jck","extended.perf","extended.system","special.functional","special.jck","special.openjdk"],
+                "21" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system","extended.jck","extended.perf","extended.system","special.functional","special.jck","special.openjdk"],
+                "25" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system","extended.jck","extended.perf","extended.system","special.functional","special.jck","special.openjdk"]
             },
             "aix_ppc64" : {
                 "8" :  [],


### PR DESCRIPTION
Adds remaining test targets for linux x64 which tested and works with linux x64 on EBC

Signed-off-by: mahdi@ibm.com