### PR TITLE
Replace artifactory link with icr link for jdk17 linux s390x

### DIFF
--- a/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
@@ -86,9 +86,9 @@ class Config17 {
                 additionalNodeLabels: [
                         openj9:  'ci.project.openj9 && hw.arch.s390x'
                 ],
-                dockerImage: 'sys-rt-docker-local/semeru/s390_rhel7_build_image',
-                dockerRegistry: 'https://docker-na.artifactory.swg-devops.com/',
-                dockerCredential : '7c1c2c28-650f-49e0-afd1-ca6b60479546',
+                dockerImage: 'runtimes/runtimes/semeru/s390_rhel7_build_image',
+                dockerRegistry: 'https://icr.io/',
+                dockerCredential : 'ea4b3e98-4334-48d4-8211-98deb8767b55',
                 dockerNode : 'sw.tool.docker',
                 buildArgs           : [
                         'openj9'      : '--create-jre-image --ssh'
@@ -344,9 +344,9 @@ class Config17 {
                 additionalNodeLabels: [
                         openj9:  'ci.project.openj9 && hw.arch.s390x'
                 ],
-                dockerImage: 'sys-rt-docker-local/semeru/s390_rhel7_build_image',
-                dockerRegistry: 'https://docker-na.artifactory.swg-devops.com/',
-                dockerCredential : '7c1c2c28-650f-49e0-afd1-ca6b60479546',
+                dockerImage: 'runtimes/runtimes/semeru/s390_rhel7_build_image',
+                dockerRegistry: 'https://icr.io/',
+                dockerCredential : 'ea4b3e98-4334-48d4-8211-98deb8767b55',
                 dockerNode : 'sw.tool.docker',
                 configureArgs       : '--enable-dtrace',
                 additionalFileNameTag: 'IBM',

--- a/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
@@ -86,7 +86,7 @@ class Config17 {
                 additionalNodeLabels: [
                         openj9:  'ci.project.openj9 && hw.arch.s390x'
                 ],
-                dockerImage: 'runtimes/runtimes/semeru/s390_rhel7_build_image',
+                dockerImage: 'runtimes/semeru/s390_rhel7_build_image',
                 dockerRegistry: 'https://icr.io/',
                 dockerCredential : 'ea4b3e98-4334-48d4-8211-98deb8767b55',
                 dockerNode : 'sw.tool.docker',
@@ -344,7 +344,7 @@ class Config17 {
                 additionalNodeLabels: [
                         openj9:  'ci.project.openj9 && hw.arch.s390x'
                 ],
-                dockerImage: 'runtimes/runtimes/semeru/s390_rhel7_build_image',
+                dockerImage: 'runtimes/semeru/s390_rhel7_build_image',
                 dockerRegistry: 'https://icr.io/',
                 dockerCredential : 'ea4b3e98-4334-48d4-8211-98deb8767b55',
                 dockerNode : 'sw.tool.docker',


### PR DESCRIPTION
 - related to: https://github.ibm.com/runtimes/automation/issues/83
 - replace artifactory links with icr links in jdk17 pipeline groovy

Signed-off-by: Aswin K R <aswinkr77@gmail.com>