### PR TITLE
Update security scan regex to include non-CE OpenJ9 builds

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -347,7 +347,7 @@ class Build {
     This is a placeholder for running security scans.
     */
     def runSecurityScan() {
-        if (env.JOB_NAME ==~ /.*jdk\d{1,2}u?-mac-x64-openj9-IBM.*/) {
+        if (env.JOB_NAME ==~ /.*jdk\d{1,2}u?-mac-x64-openj9.*/) {
             def openj9JavaToBuild = buildConfig.JAVA_TO_BUILD
             if (openj9JavaToBuild.endsWith('u')) {
                 openj9JavaToBuild = openj9JavaToBuild[0..-2]


### PR DESCRIPTION
Signed-off-by: mahdi@ibm.com