### PR TITLE
remove the certified targets from jdk26.groovy as not needed

### DIFF
--- a/pipelines/jobs/Semeru_configuration/jdk26.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk26.groovy
@@ -22,30 +22,6 @@ targetConfigurations = [
         ],
         'aarch64Mac': [
                 'openj9'
-        ],
-        'x64MacIBM'      : [
-                'openj9'
-        ],
-        'x64LinuxIBM'    : [
-                'openj9'
-        ],
-        'x64WindowsIBM'  : [
-                'openj9'
-        ],
-        'ppc64AixIBM'    : [
-                'openj9'
-        ],
-        'ppc64leLinuxIBM': [
-                'openj9'
-        ],
-        's390xLinuxIBM'  : [
-                'openj9'
-        ],
-        'aarch64LinuxIBM': [
-                'openj9'
-        ],
-        'aarch64MacIBM': [
-                'openj9'
         ]
 ]
 


### PR DESCRIPTION
Signed-off-by: mahdi@ibm.com