### PR TITLE
Ensure the correct docker image is found and tagged

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2539,8 +2539,8 @@ class Build {
                                             // When we use non-default registery, we need to add a tag includes that inorder to let in later lines be able to access image and fetch `dockerImageDigest` 
                                             def imageWithoutTag = buildConfig.DOCKER_IMAGE.contains(':') ? buildConfig.DOCKER_IMAGE.substring(0, buildConfig.DOCKER_IMAGE.lastIndexOf(':')) : buildConfig.DOCKER_IMAGE
                                             def imageTag = buildConfig.DOCKER_IMAGE.contains(':') ? buildConfig.DOCKER_IMAGE.substring(buildConfig.DOCKER_IMAGE.lastIndexOf(':') + 1) : 'latest'
-                                            def long_docker_image_name = context.sh(script: "docker image ls --format '{{.Repository}}' | grep ${imageWithoutTag} | head -n1 | awk '{print \$1}'", returnStdout:true).trim()
-                                            context.sh(script: "docker tag '${long_docker_image_name}:${imageTag}' '${buildConfig.DOCKER_IMAGE}'", returnStdout:false)
+                                            def fullImageName = context.sh(script: "docker image ls --format '/{{.Repository}}:{{.Tag}}' | grep '/${imageWithoutTag}:${imageTag}\$' | head -n1 | sed -e 's|^/||'", returnStdout:true).trim()
+                                            context.sh(script: "docker tag '${fullImageName}' '${buildConfig.DOCKER_IMAGE}'", returnStdout:false)
                                         } else {
                                             if (buildConfig.DOCKER_ARGS) {
                                                 context.sh(script: "docker pull ${buildConfig.DOCKER_IMAGE} ${buildConfig.DOCKER_ARGS}")


### PR DESCRIPTION
If the tag isn't part of the search criteria, the wrong image may be found. Either one with a different tag, or an image having a name which is a superset.

The problem was introduced via https://github.com/ibmruntimes/ci-jenkins-pipelines/pull/274

Fixes the following build failure where the wrong image is found (`adoptium_build_image_cuda`), when it should be `adoptium_build_image:centos7`.
```
20:07:10  + docker tag ghcr.io/adoptium/adoptium_build_image_cuda:centos7 ghcr.io/adoptium/adoptium_build_image:centos7
20:07:10  Error response from daemon: No such image: ghcr.io/adoptium/adoptium_build_image_cuda:centos7
```