### PR TITLE
Fix FIPS job name suffixes in openjdk_build_pipeline.groovy to match aqa-tests naming

### DIFF
--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -465,7 +465,7 @@ class Regeneration implements Serializable {
                 CI_REF: '',
                 HELPER_REF: '',
                 AQA_REF: '',
-                AQA_AUTO_GEN: false,
+                AQA_AUTO_GEN: true,
                 BUILD_ARGS: buildArgs,
                 NODE_LABEL: "${additionalNodeLabels}",
                 ADDITIONAL_TEST_LABEL: "${additionalTestLabels}",

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -193,6 +193,21 @@ class Build {
         return jobParams
     }
 
+    def getAQATestJobSuffix(testFlag) {
+		if (!testFlag) return ''
+
+		if (testFlag == 'FIPS140_2') {
+			return '_f2'
+		} else if (testFlag == 'FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced') {
+			return '_f3_strong'
+		} else if (testFlag == 'FIPS140_3_OpenJCEPlusFIPS.FIPS140-3') {
+			return '_f3_strict'
+		} else if (testFlag == 'FIPS140_3_OpenJCEPlusFIPS') {
+			return '_f3_weak'
+		}
+		return "_${testFlag.toLowerCase()}"
+	}
+
     def getCommonTestJobParams() {
         def jobParams = [:]
         String jdk_Version = getJavaVersionNumber() as String
@@ -617,8 +632,7 @@ class Build {
                         def testFlag = ''
                         if (fipsTestBuildSuffix.trim()) {
                             testFlag = fipsTestBuildSuffix.replace("fips", "FIPS")
-                            fipsTestBuildSuffix = fipsTestBuildSuffix.toLowerCase()
-                            jobParams.put('TEST_JOB_NAME', "${jobParams.TEST_JOB_NAME}_${fipsTestBuildSuffix}")
+                            jobParams.put('TEST_JOB_NAME', "${jobParams.TEST_JOB_NAME}${getAQATestJobSuffix(testFlag)}")
                         }
 
                         def jobName = jobParams.TEST_JOB_NAME


### PR DESCRIPTION
- Apply FIPS short job name in runAQATests() to align triggered job names with the shortened names generated by aqa-tests job templates (adoptium/aqa-tests#7006).

related: https://github.ibm.com/runtimes/automation/issues/792