### PR TITLE
Enable EBC on-demand Windows nodes for nightly Semeru builds

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -604,7 +604,13 @@ class Builder implements Serializable {
             }
 
             if (additionalNodeLabels != null) {
-                labels = "${additionalNodeLabels}&&${labels}"
+                // EBC: prefixed values are provisioning directives, not Jenkins label
+                // expressions — do not append the static buildTag suffix to them.
+                if (additionalNodeLabels.toString().startsWith('EBC:')) {
+                    labels = additionalNodeLabels
+                } else {
+                    labels = "${additionalNodeLabels}&&${labels}"
+                }
             }
         }
 

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2661,7 +2661,10 @@ class Build {
                             ebcGroupLabel = "EBC_Semeru_build_${labelSuffix}_${UUID.randomUUID().toString()}"
                             context.println "[EBC] group_label=${ebcGroupLabel}"
 
-                            context.println "[EBC] Calling EBC_Create_Node (env=dev, node_type=semeru, type_usage=build)..."
+                            // TIME_LIMIT must be > 0: passing 0 sets ebc_autoCompleteAfterXHours=0
+                            // which causes EBC to auto-release the node the moment it goes LIVE.
+                            // Use 6h — enough headroom for a full Windows build (~3h) plus retries.
+                            context.println "[EBC] Calling EBC_Create_Node (env=dev, node_type=semeru, type_usage=build, TIME_LIMIT=6)..."
                             def ebcCreateParams = [
                                 context.string(name: 'GROUP_LABEL',  value: ebcGroupLabel),
                                 context.string(name: 'NODE_TYPE',    value: 'semeru'),
@@ -2669,6 +2672,7 @@ class Build {
                                 context.string(name: 'OS',           value: ebcOs),
                                 context.string(name: 'ARCH',         value: ebcArch),
                                 context.string(name: 'NUM_MACHINES', value: '1'),
+                                context.string(name: 'TIME_LIMIT',   value: '6'),
                                 context.string(name: 'EBC_ENV',      value: 'dev'),
                                 context.booleanParam(name: 'WAIT',   value: true)
                             ]
@@ -2752,9 +2756,9 @@ class Build {
                             }
                         } finally {
                             if (ebcGroupLabel) {
-                                context.println "[EBC] Calling EBC_Complete to release node (group_label=${ebcGroupLabel})..."
+                                context.println "[EBC] Calling EBC_Complete to release node (label=${ebcGroupLabel})..."
                                 context.build job: 'EBC/EBC_Complete', wait: false, propagate: false,
-                                    parameters: [context.string(name: 'GROUP_LABEL', value: ebcGroupLabel)]
+                                    parameters: [context.string(name: 'LABEL', value: ebcGroupLabel)]
                                 context.println "[EBC] EBC_Complete triggered."
                             }
                         }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2631,29 +2631,94 @@ class Build {
                         def effectiveNodeLabel = buildConfig.NODE_LABEL
                         def ebcGroupLabel = ''
 
-                        // Provision an EBC node on-demand when NODE_LABEL is 'EBC'
-                        if (buildConfig.NODE_LABEL == 'EBC') {
-                            ebcGroupLabel = "EBC_Semeru_build_windows25_${UUID.randomUUID().toString()}"
-                            context.println "[EBC] Provisioning on-demand Windows build node (group_label=${ebcGroupLabel})..."
-                            context.build job: 'EBC/EBC_Create_Node', parameters: [
-                                context.string(name: 'GROUP_LABEL',      value: ebcGroupLabel),
-                                context.string(name: 'NODE_TYPE',        value: 'semeru'),
-                                context.string(name: 'TYPE_USAGE',       value: 'build'),
-                                context.string(name: 'OS',               value: 'windows'),
-                                context.string(name: 'DISTRO',           value: 'windows25'),
-                                context.string(name: 'NUM_MACHINES',     value: '1'),
-                                context.string(name: 'EBC_ENV',          value: 'prod'),
-                                context.booleanParam(name: 'WAIT',       value: true)
-                            ], wait: true, propagate: true
+                        // Provision an EBC node on-demand when NODE_LABEL starts with 'EBC:'
+                        // Format: EBC:os=<os>,arch=<arch>[,distro=<distro>]
+                        // e.g.  EBC:os=windows,arch=x86-64,distro=windows2025
+                        //       EBC:os=linux,arch=s390x,distro=rhel9
+                        //       EBC:os=aix,arch=p9
+                        if (buildConfig.NODE_LABEL.startsWith('EBC:')) {
+                            context.println "[EBC] Parsing NODE_LABEL: '${buildConfig.NODE_LABEL}'"
+                            def ebcParams = [:]
+                            buildConfig.NODE_LABEL.substring(4).split(',').each { token ->
+                                def kv = token.trim().split('=', 2)
+                                if (kv.length == 2) ebcParams[kv[0].trim()] = kv[1].trim()
+                            }
+                            def ebcOs     = ebcParams.get('os',     '')
+                            def ebcArch   = ebcParams.get('arch',   '')
+                            def ebcDistro = ebcParams.get('distro', '')
+                            context.println "[EBC] Parsed params — os=${ebcOs}, arch=${ebcArch}, distro=${ebcDistro ?: '(none)'}"
+
+                            // Validate required parameters
+                            def ebcErrors = []
+                            if (!ebcOs)   ebcErrors << "'os' is required"
+                            if (!ebcArch) ebcErrors << "'arch' is required"
+                            if (ebcOs == 'linux' && !ebcDistro) ebcErrors << "'distro' is required when os=linux"
+                            if (ebcErrors) {
+                                error("[EBC] Invalid NODE_LABEL '${buildConfig.NODE_LABEL}': ${ebcErrors.join('; ')}")
+                            }
+
+                            def labelSuffix = ebcDistro ? "${ebcDistro}_${ebcArch}" : "${ebcOs}_${ebcArch}"
+                            ebcGroupLabel = "EBC_Semeru_build_${labelSuffix}_${UUID.randomUUID().toString()}"
+                            context.println "[EBC] group_label=${ebcGroupLabel}"
+
+                            context.println "[EBC] Calling EBC_Create_Node (env=dev, node_type=semeru, type_usage=build)..."
+                            def ebcCreateParams = [
+                                context.string(name: 'GROUP_LABEL',  value: ebcGroupLabel),
+                                context.string(name: 'NODE_TYPE',    value: 'semeru'),
+                                context.string(name: 'TYPE_USAGE',   value: 'build'),
+                                context.string(name: 'OS',           value: ebcOs),
+                                context.string(name: 'ARCH',         value: ebcArch),
+                                context.string(name: 'NUM_MACHINES', value: '1'),
+                                context.string(name: 'EBC_ENV',      value: 'dev'),
+                                context.booleanParam(name: 'WAIT',   value: true)
+                            ]
+                            if (ebcDistro) ebcCreateParams << context.string(name: 'DISTRO', value: ebcDistro)
+
+                            context.build job: 'EBC/EBC_Create_Node', parameters: ebcCreateParams,
+                                wait: true, propagate: true
+                            context.println "[EBC] EBC_Create_Node completed — node provisioned with label: ${ebcGroupLabel}"
+
                             effectiveNodeLabel = ebcGroupLabel
-                            context.println "[EBC] Node ready — using label: ${effectiveNodeLabel}"
+
+                            // Poll the node's online status via Jenkins API for up to 2 minutes
+                            // before connecting, to ensure it is fully booted and stable.
+                            def jenkinsUrl = context.env.JENKINS_URL?.replaceAll('/+$', '') ?: 'https://hyc-runtimes-jenkins.swg-devops.com'
+                            def pollDeadline = System.currentTimeMillis() + 2 * 60 * 1000
+                            def pollInterval = 10  // seconds
+                            def nodeOnline = false
+                            context.println "[EBC] Polling node online status (up to 2 min, every ${pollInterval}s)..."
+                            while (System.currentTimeMillis() < pollDeadline) {
+                                try {
+                                    def apiUrl = "${jenkinsUrl}/computer/${ebcGroupLabel}/api/json?tree=offline,temporarilyOffline"
+                                    def response = new URL(apiUrl).getText(
+                                        connectTimeout: 5000,
+                                        readTimeout:    5000,
+                                        requestProperties: ['Authorization': "Basic ${"${context.env.JENKINS_USER_ID}:${context.env.JENKINS_API_TOKEN}".bytes.encodeBase64()}"]
+                                    )
+                                    def json = new groovy.json.JsonSlurper().parseText(response)
+                                    def isOnline = !json.offline && !json.temporarilyOffline
+                                    context.println "[EBC] Node status — offline=${json.offline}, temporarilyOffline=${json.temporarilyOffline} → ${isOnline ? 'ONLINE' : 'not ready yet'}"
+                                    if (isOnline) {
+                                        nodeOnline = true
+                                        break
+                                    }
+                                } catch (Exception pollEx) {
+                                    context.println "[EBC] Poll attempt failed (node may not be registered yet): ${pollEx.message}"
+                                }
+                                context.sleep(time: pollInterval, unit: 'SECONDS')
+                            }
+                            if (nodeOnline) {
+                                context.println "[EBC] Node is online and stable — proceeding to connect."
+                            } else {
+                                context.println "[EBC] WARNING: Node did not report online within 2 minutes — attempting to connect anyway."
+                            }
                         } else {
                             waitForANodeToBecomeActive(effectiveNodeLabel)
                         }
 
                         context.println "[NODE SHIFT] MOVING INTO JENKINS NODE MATCHING LABELNAME ${effectiveNodeLabel}..."
-                        try {
                         context.node(effectiveNodeLabel) {
+                            context.println "[EBC] Connected to node: ${context.NODE_NAME}"
                             addNodeToBuildDescription()
                             nonDockerNodeName = context.NODE_NAME
                             // This is to avoid windows path length issues.
@@ -2665,7 +2730,9 @@ class Build {
                                     workspace = env.CYGWIN_WORKSPACE
                                 }
                                 context.echo("Switched to using non-default workspace path ${workspace}")
+                                context.println "[EBC] Entering ws(${workspace})..."
                                 context.ws(workspace) {
+                                    context.println "[EBC] Inside ws block — calling buildScripts..."
                                     buildScripts(
                                         cleanWorkspace,
                                         cleanWorkspaceAfter,
@@ -2673,8 +2740,10 @@ class Build {
                                         filename,
                                         useAdoptShellScripts
                                     )
+                                    context.println "[EBC] buildScripts returned successfully."
                                 }
                             } else {
+                                context.println "[EBC] Non-windows — calling buildScripts..."
                                 buildScripts(
                                     cleanWorkspace,
                                     cleanWorkspaceAfter,
@@ -2682,17 +2751,12 @@ class Build {
                                     filename,
                                     useAdoptShellScripts
                                 )
+                                context.println "[EBC] buildScripts returned successfully."
                             }
+                            context.println "[EBC] Exiting node block normally."
                         }
-                        } finally {
-                            // Release EBC node after build completes (success or failure)
-                            if (ebcGroupLabel) {
-                                context.println "[EBC] Releasing node (group_label=${ebcGroupLabel})..."
-                                context.build job: 'EBC/EBC_Complete',
-                                    parameters: [context.string(name: 'LABEL', value: ebcGroupLabel)],
-                                    wait: false, propagate: false
-                            }
-                        }
+                        // NOTE: EBC_Complete (node release) intentionally omitted for debugging.
+                        // Restore once node stability is confirmed.
                         context.println "[NODE SHIFT] OUT OF JENKINS NODE (LABELNAME ${effectiveNodeLabel}!)"
                     }
                 }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2717,22 +2717,30 @@ class Build {
                         }
 
                         context.println "[NODE SHIFT] MOVING INTO JENKINS NODE MATCHING LABELNAME ${effectiveNodeLabel}..."
-                        context.node(effectiveNodeLabel) {
-                            context.println "[EBC] Connected to node: ${context.NODE_NAME}"
-                            addNodeToBuildDescription()
-                            nonDockerNodeName = context.NODE_NAME
-                            // This is to avoid windows path length issues.
-                            context.echo("checking ${buildConfig.TARGET_OS}")
-                            if (buildConfig.TARGET_OS == 'windows') {
-                                // See https://github.com/adoptium/infrastucture/issues/1284#issuecomment-621909378 for justification of the below path
-                                def workspace = 'C:/workspace/openjdk-build/'
-                                if (env.CYGWIN_WORKSPACE) {
-                                    workspace = env.CYGWIN_WORKSPACE
-                                }
-                                context.echo("Switched to using non-default workspace path ${workspace}")
-                                context.println "[EBC] Entering ws(${workspace})..."
-                                context.ws(workspace) {
-                                    context.println "[EBC] Inside ws block — calling buildScripts..."
+                        try {
+                            context.node(effectiveNodeLabel) {
+                                context.println "[EBC] Connected to node: ${context.NODE_NAME}"
+                                addNodeToBuildDescription()
+                                nonDockerNodeName = context.NODE_NAME
+                                // This is to avoid windows path length issues.
+                                context.echo("checking ${buildConfig.TARGET_OS}")
+                                if (buildConfig.TARGET_OS == 'windows') {
+                                    // See https://github.com/adoptium/infrastucture/issues/1284#issuecomment-621909378 for justification of the below path
+                                    def workspace = 'C:/workspace/openjdk-build/'
+                                    if (env.CYGWIN_WORKSPACE) {
+                                        workspace = env.CYGWIN_WORKSPACE
+                                    }
+                                    context.echo("Switched to using non-default workspace path ${workspace}")
+                                    context.ws(workspace) {
+                                        buildScripts(
+                                            cleanWorkspace,
+                                            cleanWorkspaceAfter,
+                                            cleanWorkspaceBuildOutputAfter,
+                                            filename,
+                                            useAdoptShellScripts
+                                        )
+                                    }
+                                } else {
                                     buildScripts(
                                         cleanWorkspace,
                                         cleanWorkspaceAfter,
@@ -2740,23 +2748,16 @@ class Build {
                                         filename,
                                         useAdoptShellScripts
                                     )
-                                    context.println "[EBC] buildScripts returned successfully."
                                 }
-                            } else {
-                                context.println "[EBC] Non-windows — calling buildScripts..."
-                                buildScripts(
-                                    cleanWorkspace,
-                                    cleanWorkspaceAfter,
-                                    cleanWorkspaceBuildOutputAfter,
-                                    filename,
-                                    useAdoptShellScripts
-                                )
-                                context.println "[EBC] buildScripts returned successfully."
                             }
-                            context.println "[EBC] Exiting node block normally."
+                        } finally {
+                            if (ebcGroupLabel) {
+                                context.println "[EBC] Calling EBC_Complete to release node (group_label=${ebcGroupLabel})..."
+                                context.build job: 'EBC/EBC_Complete', wait: false, propagate: false,
+                                    parameters: [context.string(name: 'GROUP_LABEL', value: ebcGroupLabel)]
+                                context.println "[EBC] EBC_Complete triggered."
+                            }
                         }
-                        // NOTE: EBC_Complete (node release) intentionally omitted for debugging.
-                        // Restore once node stability is confirmed.
                         context.println "[NODE SHIFT] OUT OF JENKINS NODE (LABELNAME ${effectiveNodeLabel}!)"
                     }
                 }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2683,39 +2683,8 @@ class Build {
                             context.println "[EBC] EBC_Create_Node completed — node provisioned with label: ${ebcGroupLabel}"
 
                             effectiveNodeLabel = ebcGroupLabel
-
-                            // Poll the node's online status via Jenkins API for up to 2 minutes
-                            // before connecting, to ensure it is fully booted and stable.
-                            def jenkinsUrl = context.env.JENKINS_URL?.replaceAll('/+$', '') ?: 'https://hyc-runtimes-jenkins.swg-devops.com'
-                            def pollDeadline = System.currentTimeMillis() + 2 * 60 * 1000
-                            def pollInterval = 10  // seconds
-                            def nodeOnline = false
-                            context.println "[EBC] Polling node online status (up to 2 min, every ${pollInterval}s)..."
-                            while (System.currentTimeMillis() < pollDeadline) {
-                                try {
-                                    def apiUrl = "${jenkinsUrl}/computer/${ebcGroupLabel}/api/json?tree=offline,temporarilyOffline"
-                                    def response = new URL(apiUrl).getText(
-                                        connectTimeout: 5000,
-                                        readTimeout:    5000,
-                                        requestProperties: ['Authorization': "Basic ${"${context.env.JENKINS_USER_ID}:${context.env.JENKINS_API_TOKEN}".bytes.encodeBase64()}"]
-                                    )
-                                    def json = new groovy.json.JsonSlurper().parseText(response)
-                                    def isOnline = !json.offline && !json.temporarilyOffline
-                                    context.println "[EBC] Node status — offline=${json.offline}, temporarilyOffline=${json.temporarilyOffline} → ${isOnline ? 'ONLINE' : 'not ready yet'}"
-                                    if (isOnline) {
-                                        nodeOnline = true
-                                        break
-                                    }
-                                } catch (Exception pollEx) {
-                                    context.println "[EBC] Poll attempt failed (node may not be registered yet): ${pollEx.message}"
-                                }
-                                context.sleep(time: pollInterval, unit: 'SECONDS')
-                            }
-                            if (nodeOnline) {
-                                context.println "[EBC] Node is online and stable — proceeding to connect."
-                            } else {
-                                context.println "[EBC] WARNING: Node did not report online within 2 minutes — attempting to connect anyway."
-                            }
+                            // WAIT:true in EBC_Create_Node already ensures the node is online
+                            // before returning — no extra polling needed here.
                         } else {
                             waitForANodeToBecomeActive(effectiveNodeLabel)
                         }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2633,7 +2633,7 @@ class Build {
 
                         // Provision an EBC node on-demand when NODE_LABEL is 'EBC'
                         if (buildConfig.NODE_LABEL == 'EBC') {
-                            ebcGroupLabel = 'EBC_' + UUID.randomUUID().toString()
+                            ebcGroupLabel = "EBC_Semeru_build_windows25_${UUID.randomUUID().toString()}"
                             context.println "[EBC] Provisioning on-demand Windows build node (group_label=${ebcGroupLabel})..."
                             context.build job: 'EBC/EBC_Create_Node', parameters: [
                                 context.string(name: 'GROUP_LABEL',      value: ebcGroupLabel),
@@ -2645,7 +2645,7 @@ class Build {
                                 context.string(name: 'EBC_ENV',          value: 'prod'),
                                 context.booleanParam(name: 'WAIT',       value: true)
                             ], wait: true, propagate: true
-                            effectiveNodeLabel = "EBC.hw.arch.x86 && EBC && ${ebcGroupLabel}"
+                            effectiveNodeLabel = ebcGroupLabel
                             context.println "[EBC] Node ready — using label: ${effectiveNodeLabel}"
                         } else {
                             waitForANodeToBecomeActive(effectiveNodeLabel)

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -2628,9 +2628,32 @@ class Build {
 
                     // Build the jdk outside of docker container...
                     } else {
-                        waitForANodeToBecomeActive(buildConfig.NODE_LABEL)
-                        context.println "[NODE SHIFT] MOVING INTO JENKINS NODE MATCHING LABELNAME ${buildConfig.NODE_LABEL}..."
-                        context.node(buildConfig.NODE_LABEL) {
+                        def effectiveNodeLabel = buildConfig.NODE_LABEL
+                        def ebcGroupLabel = ''
+
+                        // Provision an EBC node on-demand when NODE_LABEL is 'EBC'
+                        if (buildConfig.NODE_LABEL == 'EBC') {
+                            ebcGroupLabel = 'EBC_' + UUID.randomUUID().toString()
+                            context.println "[EBC] Provisioning on-demand Windows build node (group_label=${ebcGroupLabel})..."
+                            context.build job: 'EBC/EBC_Create_Node', parameters: [
+                                context.string(name: 'GROUP_LABEL',      value: ebcGroupLabel),
+                                context.string(name: 'NODE_TYPE',        value: 'semeru'),
+                                context.string(name: 'TYPE_USAGE',       value: 'build'),
+                                context.string(name: 'OS',               value: 'windows'),
+                                context.string(name: 'DISTRO',           value: 'windows25'),
+                                context.string(name: 'NUM_MACHINES',     value: '1'),
+                                context.string(name: 'EBC_ENV',          value: 'prod'),
+                                context.booleanParam(name: 'WAIT',       value: true)
+                            ], wait: true, propagate: true
+                            effectiveNodeLabel = "EBC.hw.arch.x86 && EBC && ${ebcGroupLabel}"
+                            context.println "[EBC] Node ready — using label: ${effectiveNodeLabel}"
+                        } else {
+                            waitForANodeToBecomeActive(effectiveNodeLabel)
+                        }
+
+                        context.println "[NODE SHIFT] MOVING INTO JENKINS NODE MATCHING LABELNAME ${effectiveNodeLabel}..."
+                        try {
+                        context.node(effectiveNodeLabel) {
                             addNodeToBuildDescription()
                             nonDockerNodeName = context.NODE_NAME
                             // This is to avoid windows path length issues.
@@ -2661,7 +2684,16 @@ class Build {
                                 )
                             }
                         }
-                        context.println "[NODE SHIFT] OUT OF JENKINS NODE (LABELNAME ${buildConfig.NODE_LABEL}!)"
+                        } finally {
+                            // Release EBC node after build completes (success or failure)
+                            if (ebcGroupLabel) {
+                                context.println "[EBC] Releasing node (group_label=${ebcGroupLabel})..."
+                                context.build job: 'EBC/EBC_Complete',
+                                    parameters: [context.string(name: 'LABEL', value: ebcGroupLabel)],
+                                    wait: false, propagate: false
+                            }
+                        }
+                        context.println "[NODE SHIFT] OUT OF JENKINS NODE (LABELNAME ${effectiveNodeLabel}!)"
                     }
                 }
 

--- a/pipelines/jobs/Semeru_configuration/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk11u_pipeline_config.groovy
@@ -43,7 +43,7 @@ class Config11 {
             os                  : 'windows',
             arch                : 'x64',
             additionalNodeLabels: [
-                    openj9:     'EBC',
+                    openj9:     'EBC:os=windows,arch=x86-64,distro=windows2025',
                     temurin:    'win2022&&vs2019',
                     dragonwell: 'win2012'
             ],

--- a/pipelines/jobs/Semeru_configuration/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk11u_pipeline_config.groovy
@@ -283,7 +283,7 @@ class Config11 {
             os                  : 'windows',
             arch                : 'x64',
             additionalNodeLabels: [
-                    openj9:     'ci.project.openj9 && hw.arch.x86 && sw.os.windows'
+                    openj9:     'EBC:os=windows,arch=x86-64,distro=windows2025'
             ],
             buildArgs : [
                     openj9 : '--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk11 -b ibm_sdk'

--- a/pipelines/jobs/Semeru_configuration/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk11u_pipeline_config.groovy
@@ -43,7 +43,7 @@ class Config11 {
             os                  : 'windows',
             arch                : 'x64',
             additionalNodeLabels: [
-                    openj9:     'ci.project.openj9 && hw.arch.x86 && sw.os.windows',
+                    openj9:     'EBC',
                     temurin:    'win2022&&vs2019',
                     dragonwell: 'win2012'
             ],

--- a/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
@@ -47,7 +47,7 @@ class Config17 {
                 os                  : 'windows',
                 arch                : 'x64',
                 additionalNodeLabels: [
-                        openj9 : 'ci.project.openj9 && hw.arch.x86 && sw.os.windows',
+                        openj9 : 'EBC',
                         temurin : 'win2022&&vs2019'
                 ],
                 cleanWorkspaceAfterBuild: true,

--- a/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
@@ -261,7 +261,7 @@ class Config17 {
                 os                  : 'windows',
                 arch                : 'x64',
                 additionalNodeLabels: [
-                        openj9:     'ci.project.openj9 && hw.arch.x86 && sw.os.windows'
+                        openj9:     'EBC:os=windows,arch=x86-64,distro=windows2025'
                 ],
                 buildArgs : [
                         'openj9' : '--ssh --disable-adopt-branch-safety -r git@github.ibm.com:runtimes/openj9-openjdk-jdk17 -b ibm_sdk --create-jre-image'

--- a/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
@@ -47,7 +47,7 @@ class Config17 {
                 os                  : 'windows',
                 arch                : 'x64',
                 additionalNodeLabels: [
-                        openj9 : 'EBC',
+                        openj9 : 'EBC:os=windows,arch=x86-64,distro=windows2025',
                         temurin : 'win2022&&vs2019'
                 ],
                 cleanWorkspaceAfterBuild: true,

--- a/pipelines/jobs/Semeru_configuration/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk21u_pipeline_config.groovy
@@ -258,7 +258,7 @@ class Config21 {
         x64WindowsIBM: [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: 'hw.arch.x86 && sw.os.windows',
+                additionalNodeLabels: 'EBC:os=windows,arch=x86-64,distro=windows2025',
                 cleanWorkspaceAfterBuild: true,
                 test                : 'default',
                 configureArgs       : '--with-jdk-rc-name="IBM Semeru Runtime"',

--- a/pipelines/jobs/Semeru_configuration/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk21u_pipeline_config.groovy
@@ -52,7 +52,7 @@ class Config21 {
                 os                  : 'windows',
                 arch                : 'x64',
                 additionalNodeLabels: [
-                        openj9      : 'hw.arch.x86 && sw.os.windows',
+                        openj9      : 'EBC',
                         temurin     : 'win2022&&vs2022'
                 ],
                 cleanWorkspaceAfterBuild: true,

--- a/pipelines/jobs/Semeru_configuration/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk21u_pipeline_config.groovy
@@ -52,7 +52,7 @@ class Config21 {
                 os                  : 'windows',
                 arch                : 'x64',
                 additionalNodeLabels: [
-                        openj9      : 'EBC',
+                        openj9      : 'EBC:os=windows,arch=x86-64,distro=windows2025',
                         temurin     : 'win2022&&vs2022'
                 ],
                 cleanWorkspaceAfterBuild: true,

--- a/pipelines/jobs/Semeru_configuration/jdk25_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk25_pipeline_config.groovy
@@ -29,7 +29,7 @@ class Config25 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: 'EBC',
+                additionalNodeLabels: 'EBC:os=windows,arch=x86-64,distro=windows2025',
                 cleanWorkspaceAfterBuild: true,
                 test                : 'default',
                 configureArgs       : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-jdk-rc-name="IBM Semeru Runtime"',

--- a/pipelines/jobs/Semeru_configuration/jdk25_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk25_pipeline_config.groovy
@@ -29,7 +29,7 @@ class Config25 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: 'hw.arch.x86 && sw.os.windows',
+                additionalNodeLabels: 'EBC',
                 cleanWorkspaceAfterBuild: true,
                 test                : 'default',
                 configureArgs       : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-jdk-rc-name="IBM Semeru Runtime"',

--- a/pipelines/jobs/Semeru_configuration/jdk25_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk25_pipeline_config.groovy
@@ -179,7 +179,7 @@ class Config25 {
         x64WindowsIBM: [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: 'hw.arch.x86 && sw.os.windows',
+                additionalNodeLabels: 'EBC:os=windows,arch=x86-64,distro=windows2025',
                 cleanWorkspaceAfterBuild: true,
                 test                : 'default',
                 configureArgs       : '--with-jdk-rc-name="IBM Semeru Runtime"',

--- a/pipelines/jobs/Semeru_configuration/jdk26_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk26_pipeline_config.groovy
@@ -128,7 +128,7 @@ class Config26 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: 'hw.arch.x86 && sw.os.windows',
+                additionalNodeLabels: 'EBC',
                 cleanWorkspaceAfterBuild: true,
                 test                : [
                         nightly: [

--- a/pipelines/jobs/Semeru_configuration/jdk26_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk26_pipeline_config.groovy
@@ -128,7 +128,7 @@ class Config26 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: 'EBC',
+                additionalNodeLabels: 'EBC:os=windows,arch=x86-64,distro=windows2025',
                 cleanWorkspaceAfterBuild: true,
                 test                : [
                         nightly: [

--- a/pipelines/jobs/Semeru_configuration/jdk27_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk27_pipeline_config.groovy
@@ -128,7 +128,7 @@ class Config27 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: 'EBC',
+                additionalNodeLabels: 'EBC:os=windows,arch=x86-64,distro=windows2025',
                 cleanWorkspaceAfterBuild: true,
                 test                : [
                         nightly: [

--- a/pipelines/jobs/Semeru_configuration/jdk27_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk27_pipeline_config.groovy
@@ -128,7 +128,7 @@ class Config27 {
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: 'hw.arch.x86 && sw.os.windows',
+                additionalNodeLabels: 'EBC',
                 cleanWorkspaceAfterBuild: true,
                 test                : [
                         nightly: [

--- a/pipelines/jobs/Semeru_configuration/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk8u_pipeline_config.groovy
@@ -91,7 +91,7 @@ class Config8 {
                 additionalNodeLabels: [
                         temurin : 'win2022&&vs2017',
                         corretto: 'win2012',
-                        openj9  : 'EBC',
+                        openj9  : 'EBC:os=windows,arch=x86-64,distro=windows2025',
                         dragonwell: 'win2012'
                 ],
                 test                : [

--- a/pipelines/jobs/Semeru_configuration/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk8u_pipeline_config.groovy
@@ -91,7 +91,7 @@ class Config8 {
                 additionalNodeLabels: [
                         temurin : 'win2022&&vs2017',
                         corretto: 'win2012',
-                        openj9  : 'ci.project.openj9 && hw.arch.x86 && sw.os.windows',
+                        openj9  : 'EBC',
                         dragonwell: 'win2012'
                 ],
                 test                : [


### PR DESCRIPTION
Tracks https://github.ibm.com/runtimes/automation/issues/1145

## Changes

### Pipeline configs
Updated `additionalNodeLabels` for `x64Windows` (OE) and `x64WindowsIBM` (CE) `openj9` targets from static `hw.arch.x86 && sw.os.windows` → `EBC:os=windows,arch=x86-64,distro=windows2025`:

| File | OE (x64Windows) | CE (x64WindowsIBM) |
|---|---|---|
| jdk8u | ✅ | — (no IBM variant; x32Windows kept static) |
| jdk11u | ✅ | ✅ |
| jdk17u | ✅ | ✅ |
| jdk21u | ✅ | ✅ |
| jdk25 | ✅ | ✅ |
| jdk26 | ✅ | — (no IBM variant) |
| jdk27 | ✅ | — (no IBM variant) |

### `build_base_file.groovy`
When `additionalNodeLabels` starts with `EBC:`, skip appending the static `&&ci.role.build.release && ci.project.openj9` suffix, so the EBC label reaches `openjdk_build_pipeline.groovy` intact. Works for both map-form and plain-string form.

### `openjdk_build_pipeline.groovy`
When `NODE_LABEL` starts with `EBC:`, the pipeline:
1. Parses the structured label (`os`, `arch`, `distro` keys)
2. Calls `EBC/EBC_Create_Node` (`NODE_TYPE=semeru`, `TYPE_USAGE=build`, `TIME_LIMIT=6`, `WAIT=true`) to provision an on-demand Windows 2025 node
3. Connects to the provisioned node via its UUID label
4. Releases via `EBC/EBC_Complete` in a `finally` block — guaranteed even on failure or abort

Non-EBC targets fall through to the existing `waitForANodeToBecomeActive` + `node()` path unchanged.

## Why
EBC Windows 2025 builds take ~3h vs 4h on static `ci.role.build.release` machines, with zero idle cost. The EBC recipe (`runtimesJenkins-semeru-build-windows-x86-64-windows2025-large.yml`) is already merged upstream.

## Test results

| Build | Type | Result |
|---|---|---|
| [jdk11u-windows-x64-openj9 #1578](https://hyc-runtimes-jenkins.swg-devops.com/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-windows-x64-openj9/1578/) | EBC Windows 2025 (OE) | ✅ **SUCCESS** ~3h |
| [EBC_Create_Node #14542](https://hyc-runtimes-jenkins.swg-devops.com/job/EBC/job/EBC_Create_Node/14542/) | Node provisioning | ✅ **SUCCESS** ~43 min |
| [jdk11u-linux-x64-openj9 #1818](https://hyc-runtimes-jenkins.swg-devops.com/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-linux-x64-openj9/1818/) | Linux non-EBC regression | ✅ **SUCCESS** |

Full EBC lifecycle confirmed in console for #1578:
- `EBC_Create_Node` with `TIME_LIMIT=6` ✅
- Node `10.15.151.77` (EBC Windows 2025) connected ✅
- Full JDK 11 build completed (~3h) ✅
- `EBC_Complete` fired in `finally` with correct `LABEL` param ✅