### PR TITLE
Add jdk27 to ebcEnabledTargets in semeru_defaults.json

### DIFF
--- a/pipelines/semeru_defaults.json
+++ b/pipelines/semeru_defaults.json
@@ -122,7 +122,8 @@
                 "17" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system","extended.jck","extended.perf","extended.system","special.functional","special.jck","special.openjdk"],
                 "21" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system","extended.jck","extended.perf","extended.system","special.functional","special.jck","special.openjdk"],
                 "25" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system","extended.jck","extended.perf","extended.system","special.functional","special.jck","special.openjdk"],
-                "26" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system","extended.jck","extended.perf","extended.system","special.functional","special.jck","special.openjdk"]
+                "26" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system","extended.jck","extended.perf","extended.system","special.functional","special.jck","special.openjdk"],
+                "27" : ["extended.functional","extended.openjdk","sanity.functional","sanity.jck","sanity.openjdk","sanity.perf","sanity.system","special.system","extended.jck","extended.perf","extended.system","special.functional","special.jck","special.openjdk"]
             },
             "aix_ppc64" : {
                 "8" :  [],
@@ -130,7 +131,8 @@
                 "17" : [],
                 "21" : [],
                 "25" : [],
-                "26" : []
+                "26" : [],
+                "27" : []
             },
             "linux_aarch64" : {
                 "8" :  [],
@@ -138,7 +140,8 @@
                 "17" : [],
                 "21" : [],
                 "25" : [],
-                "26" : []
+                "26" : [],
+                "27" : []
             },
             "linux_ppc64le" : {
                 "8" :  [],
@@ -146,7 +149,8 @@
                 "17" : [],
                 "21" : [],
                 "25" : [],
-                "26" : []
+                "26" : [],
+                "27" : []
             },
             "linux_s390x" : {
                 "8" :  [],
@@ -154,7 +158,8 @@
                 "17" : [],
                 "21" : [],
                 "25" : [],
-                "26" : []
+                "26" : [],
+                "27" : []
             },
             "mac_aarch64" : {
                 "8" :  [],
@@ -162,7 +167,8 @@
                 "17" : [],
                 "21" : [],
                 "25" : [],
-                "26" : []
+                "26" : [],
+                "27" : []
             },
             "mac_x64" : {
                 "8" :  [],
@@ -170,7 +176,8 @@
                 "17" : [],
                 "21" : [],
                 "25" : [],
-                "26" : []
+                "26" : [],
+                "27" : []
             },
             "windows-x64" : {
                 "8" :  [],
@@ -178,7 +185,8 @@
                 "17" : [],
                 "21" : [],
                 "25" : [],
-                "26" : []
+                "26" : [],
+                "27" : []
             },
             "windows-x32" : {
                 "8" :  [],
@@ -186,7 +194,8 @@
                 "17" : [],
                 "21" : [],
                 "25" : [],
-                "26" : []
+                "26" : [],
+                "27" : []
             }
         }
     },


### PR DESCRIPTION
jdk27 was missing from ebcEnabledTargets across all platforms — added alongside jdk26 with the same test lists (linux_x64 gets the full set, all other platforms keep empty lists matching the jdk26 pattern).

Tracked-by: https://github.ibm.com/runtimes/automation/issues/1145