### PR TITLE
Disable OE nightly tests for CE versions (jdk11u/17u/21u/25)

### DIFF
--- a/pipelines/jobs/Semeru_configuration/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk11u_pipeline_config.groovy
@@ -5,7 +5,7 @@ class Config11 {
             os                  : 'mac',
             arch                : 'x64',
             additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.mac',
-            test                : 'default',
+            test                : false,
             configureArgs       : [
                     'openj9'      : '--enable-dtrace=auto  --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                     ],
@@ -25,7 +25,7 @@ class Config11 {
             ],
             additionalNodeLabels : 'ci.project.openj9 && hw.arch.x86 && sw.os.linux',
             dockerNode          : 'sw.tool.docker',
-            test                : 'default',
+            test                : false,
             configureArgs       : [
                     'openj9'      : '--disable-ccache --enable-dtrace=auto --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
                     'corretto'    : '--enable-dtrace=auto',
@@ -47,7 +47,7 @@ class Config11 {
                     temurin:    'win2022&&vs2019',
                     dragonwell: 'win2012'
             ],
-            test                : 'default',
+            test                : false,
             buildArgs : [
                 'openj9'    : '--ssh'
             ],
@@ -63,7 +63,7 @@ class Config11 {
                     openj9:  'hw.arch.ppc64 && sw.os.aix.7_2 && sw.tool.c++runtime.16_1',
                     temurin: 'xlc13&&aix720'
             ],
-            test                : 'default',
+            test                : false,
             additionalTestLabels: [
                     temurin: 'sw.os.aix.7_2'
             ],
@@ -79,7 +79,7 @@ class Config11 {
         s390xLinux    : [
             os                  : 'linux',
             arch                : 's390x',
-            test                : 'default',
+            test                : false,
             additionalNodeLabels: [
                     openj9:  'ci.project.openj9 && hw.arch.s390x'
             ],
@@ -96,7 +96,7 @@ class Config11 {
         ppc64leLinux    : [
             os                  : 'linux',
             arch                : 'ppc64le',
-            test                : 'default',
+            test                : false,
             dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
             dockerRegistry      : 'https://ghcr.io/',
             dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
@@ -125,7 +125,7 @@ class Config11 {
             additionalNodeLabels: [
                     openj9:  'hw.arch.aarch64 && sw.os.linux'
             ],
-            test                : 'default',
+            test                : false,
             configureArgs       : [
                     'openj9' : '--enable-dtrace=auto  --without-version-opt  --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
                     'corretto' : '--enable-dtrace=auto',
@@ -191,7 +191,7 @@ class Config11 {
                         'bisheng'   : '--enable-dtrace=auto --with-extra-cflags=-fstack-protector-strong --with-extra-cxxflags=-fstack-protector-strong --with-jvm-variants=server'
                 ],
                 test                : [
-                        openj9 : 'default'
+                        openj9 : false
                 ],
                 buildArgs           : [
                         'openj9'    : '--ssh'

--- a/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk17u_pipeline_config.groovy
@@ -8,7 +8,7 @@ class Config17 {
                 additionalTestLabels: [
                         openj9      : ''
                 ],
-                test                : 'default',
+                test                : false,
                 cleanWorkspaceAfterBuild: true,
                 buildArgs           : [
                         'openj9'      : '--create-jre-image --ssh'
@@ -30,7 +30,7 @@ class Config17 {
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 dockerNode          : 'sw.tool.docker',
-                test                : 'default',
+                test                : false,
                 cleanWorkspaceAfterBuild: true,
                 additionalTestLabels: [
                         openj9      : '!(sw.os.cent.6||sw.os.rhel.6)'
@@ -55,7 +55,7 @@ class Config17 {
                         'openj9'    : '--create-jre-image --ssh'
                         ],
                 configureArgs: '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-jdk-rc-name="IBM Semeru Runtime"',
-                test                : 'default'
+                test                : false
         ],
 
         ppc64Aix    : [
@@ -65,7 +65,7 @@ class Config17 {
                         temurin: 'xlc13&&aix720',
                         openj9:  'hw.arch.ppc64 && sw.os.aix.7_2 && sw.tool.c++runtime.16_1'
                 ],
-                test                : 'default',
+                test                : false,
                 additionalTestLabels:  [
                         temurin: 'sw.os.aix.7_2'
                 ],
@@ -81,7 +81,7 @@ class Config17 {
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                test                : 'default',
+                test                : false,
                 cleanWorkspaceAfterBuild: true,
                 additionalNodeLabels: [
                         openj9:  'ci.project.openj9 && hw.arch.s390x'
@@ -104,7 +104,7 @@ class Config17 {
                 dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
                 dockerRegistry      : 'https://ghcr.io/',
                 dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
-                test                : 'default',
+                test                : false,
                 cleanWorkspaceAfterBuild: true,
                 additionalNodeLabels: [
                     openj9:  'ci.project.openj9 && hw.arch.ppc64le && sw.os.linux'
@@ -128,7 +128,7 @@ class Config17 {
                 dockerRegistry      : 'https://ghcr.io/',
                 dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
                 dockerNode         : 'sw.tool.docker',
-                test                : 'default',
+                test                : false,
                 additionalNodeLabels: [
                         openj9:  'hw.arch.aarch64 && sw.os.linux'
                 ],
@@ -153,7 +153,7 @@ class Config17 {
                 ],
                 test                : [
                         temurin : 'default',
-                        openj9 : 'default'
+                        openj9 : false
                 ],
                 buildArgs           : [
                         'openj9'    : '--create-jre-image --ssh'
@@ -166,7 +166,7 @@ class Config17 {
                 dockerImage         : 'adoptopenjdk/ubuntu2004_build_image:linux-riscv64',
                 crossCompile        : 'qemustatic',
                 dockerArgs          : '--platform linux/riscv64',
-                test                : 'default',
+                test                : false,
                 configureArgs       : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
                         ]

--- a/pipelines/jobs/Semeru_configuration/jdk21u_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk21u_pipeline_config.groovy
@@ -11,7 +11,7 @@ class Config21 {
                 additionalTestLabels: [
                         openj9      : ''
                 ],
-                test                : 'default',
+                test                : false,
                 configureArgs       : [
                         openj9      : '--enable-dtrace --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
                         temurin     : '--enable-dtrace'
@@ -31,7 +31,7 @@ class Config21 {
                         openj9      : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 dockerNode          : 'sw.tool.docker',
-                test                : 'default',
+                test                : false,
                 cleanWorkspaceAfterBuild: true,
                 additionalNodeLabels: [
                         openj9      : 'hw.arch.x86 && sw.os.linux'
@@ -56,7 +56,7 @@ class Config21 {
                         temurin     : 'win2022&&vs2022'
                 ],
                 cleanWorkspaceAfterBuild: true,
-                test                : 'default',
+                test                : false,
                 configureArgs       : [
                         openj9      : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-jdk-rc-name="IBM Semeru Runtime"'
                 ],
@@ -72,7 +72,7 @@ class Config21 {
                         temurin: 'xlc16&&aix720',
                         openj9:  'hw.arch.ppc64 && sw.os.aix.7_2 && sw.tool.c++runtime.16_1'
                 ],
-                test                : 'default',
+                test                : false,
                 additionalTestLabels: [
                         temurin      : 'sw.os.aix.7_2'
                 ],
@@ -88,7 +88,7 @@ class Config21 {
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                test                : 'default',
+                test                : false,
                 cleanWorkspaceAfterBuild: true,
                 additionalNodeLabels: [
                         openj9:  'ci.project.openj9 && hw.arch.s390x'
@@ -111,7 +111,7 @@ class Config21 {
                 dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:centos7',
                 dockerRegistry      : 'https://ghcr.io/',
                 dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
-                test                : 'default',
+                test                : false,
                 cleanWorkspaceAfterBuild: true,
                 additionalNodeLabels: [
                     openj9:  'ci.project.openj9 && hw.arch.ppc64le && sw.os.linux'
@@ -138,7 +138,7 @@ class Config21 {
                 additionalNodeLabels: [
                         openj9      : 'hw.arch.aarch64 && sw.os.linux'
                 ],
-                test                : 'default',
+                test                : false,
                 configureArgs : [
                         'openj9'    : '--enable-dtrace --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                         ],
@@ -156,7 +156,7 @@ class Config21 {
                         temurin     : 'xcode15.0.1'
                 ],
                 cleanWorkspaceAfterBuild: true,
-                test                : 'default',
+                test                : false,
                 configureArgs       : [
                         openj9      : '--enable-dtrace --disable-warnings-as-errors --with-noncompressedrefs --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"'
                 ],
@@ -171,7 +171,7 @@ class Config21 {
                 crossCompile        : 'qemustatic',
                 dockerImage         : 'ghcr.io/adoptium/adoptium_build_image:ubuntu2004_linux-riscv64',
                 dockerArgs          : '--platform linux/riscv64',
-                test                : 'default',
+                test                : false,
                 configureArgs       : '--enable-headless-only=yes --enable-dtrace',
                 buildArgs           : [
                         ]

--- a/pipelines/jobs/Semeru_configuration/jdk25_pipeline_config.groovy
+++ b/pipelines/jobs/Semeru_configuration/jdk25_pipeline_config.groovy
@@ -6,7 +6,7 @@ class Config25 {
                 arch                : 'x64',
                 additionalNodeLabels: 'ci.project.openj9 && hw.arch.x86 && sw.os.mac',
                 additionalTestLabels: '!sw.os.osx.10_15',
-                test                : 'default',
+                test                : false,
                 configureArgs       : '--enable-dtrace --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
                 buildArgs           : '--create-jre-image --ssh'
         ],
@@ -19,7 +19,7 @@ class Config25 {
                 dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
                 dockerFile          : 'pipelines/build/dockerFiles/cuda.dockerfile',
                 dockerNode          : 'sw.tool.docker',
-                test                : 'default',
+                test                : false,
                 cleanWorkspaceAfterBuild: true,
                 additionalNodeLabels: 'hw.arch.x86 && sw.os.linux',
                 configureArgs       : '--enable-dtrace --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
@@ -31,7 +31,7 @@ class Config25 {
                 arch                : 'x64',
                 additionalNodeLabels: 'EBC:os=windows,arch=x86-64,distro=windows2025',
                 cleanWorkspaceAfterBuild: true,
-                test                : 'default',
+                test                : false,
                 configureArgs       : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition" --with-jdk-rc-name="IBM Semeru Runtime"',
                 buildArgs           : '--create-jre-image --ssh'
         ],
@@ -40,7 +40,7 @@ class Config25 {
                 os                  : 'aix',
                 arch                : 'ppc64',
                 additionalNodeLabels: 'hw.arch.ppc64 && sw.os.aix.7_2 && sw.tool.c++runtime.17_1',
-                test                : 'default',
+                test                : false,
                 cleanWorkspaceAfterBuild: true,
                 configureArgs       : '--disable-ccache --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
                 buildArgs           : '--create-jre-image --ssh'
@@ -49,7 +49,7 @@ class Config25 {
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                test                : 'default',
+                test                : false,
                 cleanWorkspaceAfterBuild: true,
                 additionalNodeLabels: 'ci.project.openj9 && hw.arch.s390x',
                 dockerImage: 'runtimes/ibm-java-8/s390x-redhat7:gcc14_semeru',
@@ -68,7 +68,7 @@ class Config25 {
                 dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
                 dockerFile          : 'pipelines/build/dockerFiles/cuda.dockerfile',
                 dockerNode         : 'sw.tool.docker',
-                test                : 'default',
+                test                : false,
                 cleanWorkspaceAfterBuild: true,
                 additionalNodeLabels: 'ci.project.openj9 && hw.arch.ppc64le && sw.os.linux',
                 configureArgs       : '--with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
@@ -83,7 +83,7 @@ class Config25 {
                 dockerCredential    : 'f5a0bd2f-093e-41ea-bd6f-875936334a63',
                 dockerNode          : 'sw.tool.docker',
                 additionalNodeLabels: 'hw.arch.aarch64 && sw.os.linux',
-                test                : 'default',
+                test                : false,
                 configureArgs       : '--enable-dtrace --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
                 cleanWorkspaceAfterBuild : true,
                 buildArgs           : '--create-jre-image --ssh'
@@ -94,7 +94,7 @@ class Config25 {
                 arch                : 'aarch64',
                 additionalNodeLabels: 'ci.project.openj9 && hw.arch.aarch64 && sw.os.mac',
                 cleanWorkspaceAfterBuild: true,
-                test                : 'default',
+                test                : false,
                 configureArgs       : '--enable-dtrace --disable-warnings-as-errors --with-noncompressedrefs --with-product-name="IBM Semeru Runtime" --with-product-suffix="Open Edition"',
                 buildArgs           : '--create-jre-image --ssh'
         ],


### PR DESCRIPTION
## Problem
For versions that ship both OE and CE (IBM-suffixed) builds (jdk11u, jdk17u, jdk21u, jdk25), the OE platform configs had `test: 'default'` which caused the full `nightlyDefault` test suite to run on **both** OE and CE nightly builds — duplicating work and wasting resources.

Confirmed via Jenkins job history: both `openjdk11-pipeline` and `openjdk11-pipeline-IBM` triggered nightly builds with identical `TEST_LIST` on every platform.

## Fix
Set `test: false` on all OE platforms in `jdk11u`, `jdk17u`, `jdk21u`, `jdk25` `_pipeline_config.groovy` files so nightly testing only runs on CE (IBM-suffixed) platforms.

## Not changed
- `jdk8u` and `jdk27` — OE-only versions, nightly tests must remain
- All IBM-suffixed CE platform entries — untouched
- Weekly test lists — untouched